### PR TITLE
Skip already excluded directories

### DIFF
--- a/asimov
+++ b/asimov
@@ -20,7 +20,7 @@ set -Eeu -o pipefail
 readonly ASIMOV_ROOT=~
 
 # Paths to unconditionally skip over. This prevents Asimov from modifying the
-# Time Machine exclusions for these paths (and decendents). It has an important
+# Time Machine exclusions for these paths (and descendants). It has an important
 # side-effect of speeding up the search.
 readonly ASIMOV_SKIP_PATHS=(
     ~/.Trash

--- a/asimov
+++ b/asimov
@@ -50,8 +50,6 @@ readonly ASIMOV_VENDOR_DIR_SENTINELS=(
     'Carthage Cartfile'                # Carthage
     'Pods Podfile'                     # CocoaPods
     'bower_components bower.json'      # Bower (JavaScript)
-    'build build.gradle'               # Gradle
-    'build build.gradle.kts'           # Gradle Kotlin Script
     'build pubspec.yaml'               # Flutter (Dart)
     'build setup.py'                   # Python
     'dist setup.py'                    # PyPI Publishing (Python)

--- a/asimov
+++ b/asimov
@@ -94,6 +94,11 @@ declare -a find_parameters_skip=()
 for d in "${ASIMOV_SKIP_PATHS[@]}"; do
     find_parameters_skip+=( -not \( -path "${d}" -prune \) )
 done
+# Collect already excluded directories to not descent into them
+while IFS= read -r line
+do
+    find_parameters_skip+=( -not \( -path "${line}" -prune \) )
+done < <(mdfind -onlyin "${ASIMOV_ROOT}" com_apple_backup_excludeItem = 'com.apple.backupd' | sort | uniq)
 
 # Iterate over the directory/sentinel pairs to construct the `find` expression.
 declare -a find_parameters_vendor=()


### PR DESCRIPTION
I've a `~/development/project` directory which is manually marked as excluded from Time Machine.
Previously `asimov` would iterate over its subdirectories, now it won't.

Also, subsequent runs could benefit from that feature.


Using `mdfind` instead of `find "${ASIMOV_ROOT}" -type d -xattrname "com.apple.metadata:com_apple_backup_excludeItem" -prune -print` as it's superfast. Though it has a downside: some excluded directories are not reported.