### PR TITLE
Add direnv output directory sentinel

### DIFF
--- a/asimov
+++ b/asimov
@@ -70,6 +70,7 @@ readonly ASIMOV_VENDOR_DIR_SENTINELS=(
     '.terraform.d .terraformrc'        # Terraform plugin cache
     '.terragrunt-cache terragrunt.hcl' # Terragrunt
     'cdk.out cdk.json'                 # AWS CDK
+    '.direnv .envrc'                   # direnv
 )
 
 # Exclude the given paths from Time Machine backups.


### PR DESCRIPTION
This adds `.direnv` directories next to a `.envrc` file. This directory contains some auto-generated files to speed up direnv's activation of the `.envrc` file. These files are recreated when direnv activates again.