### PR TITLE
feat(app-caches): exclude non-developer application caches (RFC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   most users get — `asimov` starts with `#!/usr/bin/env bash`, and a development machine
   usually has 5.x first on `PATH`. `make test BASH_BIN=<path>` pins any interpreter, and
   `make test BATS_JOBS=N` runs tests concurrently (needs GNU parallel).
+- Application cache exclusions: Spotify's offline storage, Chrome's on-device model stores,
+  and the `Cache` / `Code Cache` / `GPUCache` / `CachedData` / `CachedExtensionVSIXs` /
+  `*_crx_cache` directories that Electron and Chromium apps keep in
+  `~/Library/Application Support` (which, unlike `~/Library/Caches`, Time Machine does back up).
+  Enabled by default on new installs and off for anyone upgrading; controlled by
+  `[app_caches] enabled`. Resolves [#39](https://github.com/AsimovMac/asimov/issues/39).
+- Fixed-directory paths now support globs (`*`, `?`, `[...]`), both in the built-in lists and
+  in `[fixed_dirs] extra` — including paths that contain spaces.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   most users get — `asimov` starts with `#!/usr/bin/env bash`, and a development machine
   usually has 5.x first on `PATH`. `make test BASH_BIN=<path>` pins any interpreter, and
   `make test BATS_JOBS=N` runs tests concurrently (needs GNU parallel).
-- Application cache exclusions: Spotify's offline storage, Chrome's on-device model stores,
-  and the `Cache` / `Code Cache` / `GPUCache` / `CachedData` / `CachedExtensionVSIXs` /
-  `*_crx_cache` directories that Electron and Chromium apps keep in
-  `~/Library/Application Support` (which, unlike `~/Library/Caches`, Time Machine does back up).
+- Application cache exclusions, covering the caches Electron and Chromium apps keep in
+  `~/Library/Application Support` (which, unlike `~/Library/Caches`, Time Machine does back up):
+  `Cache`, `Code Cache`, `GPUCache`, `CachedData`, `CachedExtensionVSIXs`, the four Chromium
+  shader caches, `*_crx_cache`, on-device model stores, `WidevineCdm`, `Safe Browsing`,
+  `Crashpad`, `blob_storage`, `update-cache`, editor `WebStorage/*/CacheStorage`, plus
+  vendor-specific caches for Spotify, Notion, Steam, Google Updater, Google Drive, Setapp,
+  SketchUp and Arc. Measured at 18 GB across 361 directories on one everyday Mac.
   Enabled by default on new installs and off for anyone upgrading; controlled by
   `[app_caches] enabled`. Resolves [#39](https://github.com/AsimovMac/asimov/issues/39).
 - Fixed-directory paths now support globs (`*`, `?`, `[...]`), both in the built-in lists and

--- a/README.md
+++ b/README.md
@@ -183,11 +183,11 @@ extra   = ~/builds/*/dist        # globs work, including in paths containing spa
 
 ### Application caches
 
-macOS already keeps `~/Library/Caches` out of Time Machine — but Electron and Chromium apps
+macOS already keeps `~/Library/Caches` out of Time Machine, but Electron and Chromium apps
 store their caches in `~/Library/Application Support`, which *is* backed up. Asimov excludes
-those too: Spotify's offline audio, Chrome's on-device model store, and the
-`Cache` / `Code Cache` / `GPUCache` / `CachedExtensionVSIXs` directories that every
-Electron app leaves behind. On one everyday Mac this came to 14 GB.
+those too: Spotify's offline audio, browser on-device model stores, shader caches, crash
+dumps, and the `Cache` / `Code Cache` / `GPUCache` / `CachedExtensionVSIXs` directories that
+every Electron app leaves behind. On one everyday Mac this came to 18 GB across 361 directories.
 
 This is **on by default for new installs only**. If you were already running Asimov before
 this landed, nothing changes until you ask for it:

--- a/README.md
+++ b/README.md
@@ -178,6 +178,28 @@ Global tool caches in your home directory (`~/.cache`, `~/.gradle/caches`, …) 
 enabled = true                   # exclude the built-in global caches
 extra   = ~/my-build-cache       # plus any paths you name (always excluded when they exist)
 extra   = ~/golang/pkg/mod       # e.g. a Go module cache under a custom GOPATH
+extra   = ~/builds/*/dist        # globs work, including in paths containing spaces
+```
+
+### Application caches
+
+macOS already keeps `~/Library/Caches` out of Time Machine — but Electron and Chromium apps
+store their caches in `~/Library/Application Support`, which *is* backed up. Asimov excludes
+those too: Spotify's offline audio, Chrome's on-device model store, and the
+`Cache` / `Code Cache` / `GPUCache` / `CachedExtensionVSIXs` directories that every
+Electron app leaves behind. On one everyday Mac this came to 14 GB.
+
+This is **on by default for new installs only**. If you were already running Asimov before
+this landed, nothing changes until you ask for it:
+
+```ini
+[app_caches]
+enabled = true                   # existing users: opt in
+```
+
+```ini
+[app_caches]
+enabled = false                  # new installs: opt out
 ```
 
 ## Other install methods

--- a/asimov
+++ b/asimov
@@ -54,6 +54,12 @@ print_usage() {
     printf '\n'
     printf '  [scan]\n'
     printf '  extra = /private/var/www\n'
+    printf '\n'
+    printf 'Application caches (Spotify, Electron apps, browser model stores) are excluded\n'
+    printf 'by default on new installs. Turn them off with:\n'
+    printf '\n'
+    printf '  [app_caches]\n'
+    printf '  enabled = false\n'
 }
 
 # Parse options (before we need ASIMOV_ROOT).
@@ -152,12 +158,30 @@ readonly ASIMOV_EXCLUDED_STATE="${ASIMOV_ROOT}/.cache/asimov/excluded"
 readonly ASIMOV_FAILED_STATE="${ASIMOV_ROOT}/.cache/asimov/failed"
 readonly ASIMOV_MDFIND_SEEN="${ASIMOV_ROOT}/.cache/asimov/mdfind_seen"
 
+# Durable record of which defaults this installation was set up with. Lives in
+# ~/.local/state (not ~/.cache) precisely because it must survive a cache wipe.
+readonly ASIMOV_PROFILE_STATE="${ASIMOV_ROOT}/.local/state/asimov/profile"
+
+# Note whether this machine carries state from an earlier Asimov run. Computed
+# here, before the --no-read-cache branch below deletes any of it — otherwise an
+# upgrader whose first run is --full-scan would look like a brand-new install and
+# silently pick up new defaults.
+if [[ -e "$ASIMOV_EXCLUDED_STATE" || -e "$ASIMOV_FAILED_STATE" \
+   || -e "$ASIMOV_MDFIND_SEEN" || -e "${ASIMOV_ROOT}/.cache/asimov/paths" ]]; then
+    readonly ASIMOV_HAD_PRIOR_STATE=true
+else
+    readonly ASIMOV_HAD_PRIOR_STATE=false
+fi
+
 # Load optional config from ~/.config/asimov/config.
 # Populates ASIMOV_CONFIG_* variables. Missing file is silently ignored.
 load_config() {
     local config_file="${ASIMOV_ROOT}/.config/asimov/config"
 
     ASIMOV_CONFIG_FIXED_DIRS_ENABLED=false
+    # Empty means "not set" — the default is resolved later from the install
+    # profile, so we must be able to tell an absent key from an explicit false.
+    ASIMOV_CONFIG_APP_CACHES_ENABLED=''
     ASIMOV_CONFIG_EXTRA_FIXED_DIRS=()
     ASIMOV_CONFIG_EXTRA_SENTINELS=()
     ASIMOV_CONFIG_DISABLED_SENTINELS=()
@@ -189,6 +213,9 @@ load_config() {
                 fixed_dirs:extra)
                     value="${value/#\~/$HOME}"
                     ASIMOV_CONFIG_EXTRA_FIXED_DIRS+=("$value")
+                    ;;
+                app_caches:enabled)
+                    ASIMOV_CONFIG_APP_CACHES_ENABLED="$value"
                     ;;
                 scan:extra)
                     value="${value/#\~/$HOME}"
@@ -671,6 +698,8 @@ readonly ASIMOV_VENDOR_DIR_SENTINELS=(
 # Unlike sentinel-based pairs above, these directories are always excluded
 # when they exist — they represent global tool caches and artifacts that
 # can be safely restored.
+#
+# Entries may contain glob metacharacters (*, ?, [...]); see expand_fixed_dir.
 readonly ASIMOV_FIXED_DIRS=(
     "${ASIMOV_ROOT}/.cache"                           # XDG cache directory
     "${ASIMOV_ROOT}/.gradle/caches"                   # Gradle download cache
@@ -682,6 +711,86 @@ readonly ASIMOV_FIXED_DIRS=(
     "${ASIMOV_ROOT}/.kube/http-cache"                 # Kubernetes HTTP cache
     "${ASIMOV_ROOT}/go/pkg/mod"                       # Go module cache (0555 inside; exclude as a whole)
 )
+
+# Non-developer application caches, controlled by [app_caches] enabled.
+#
+# Only ~/Library/Application Support is worth listing here. macOS already excludes
+# ~/Library/Caches, ~/Library/Logs, ~/Library/Containers and ~/.Trash from Time
+# Machine, so anything under those is already handled — but Electron and Chromium
+# apps keep their caches in Application Support, which *is* backed up.
+#
+# Cache directory names appear both one and two levels down (e.g. Code/Cache and
+# Arc/User Data/Code Cache), and a glob does not cross a slash, so each name is
+# listed at both depths.
+readonly ASIMOV_APP_SUPPORT="${ASIMOV_ROOT}/Library/Application Support"
+readonly ASIMOV_APP_CACHE_DIRS=(
+    "${ASIMOV_APP_SUPPORT}/*/Cache"                     # Electron HTTP cache
+    "${ASIMOV_APP_SUPPORT}/*/*/Cache"
+    "${ASIMOV_APP_SUPPORT}/*/Code Cache"                # compiled-JS cache
+    "${ASIMOV_APP_SUPPORT}/*/*/Code Cache"
+    "${ASIMOV_APP_SUPPORT}/*/GPUCache"                  # shader cache
+    "${ASIMOV_APP_SUPPORT}/*/*/GPUCache"
+    "${ASIMOV_APP_SUPPORT}/*/DawnWebGPUCache"           # WebGPU shader cache
+    "${ASIMOV_APP_SUPPORT}/*/*/DawnWebGPUCache"
+    "${ASIMOV_APP_SUPPORT}/*/CachedData"                # VS Code-family V8 code cache
+    "${ASIMOV_APP_SUPPORT}/*/CachedExtensionVSIXs"      # re-downloadable .vsix archives
+    "${ASIMOV_APP_SUPPORT}/*/component_crx_cache"       # Chromium component downloads
+    "${ASIMOV_APP_SUPPORT}/*/*/component_crx_cache"
+    "${ASIMOV_APP_SUPPORT}/*/extensions_crx_cache"      # Chromium extension downloads
+    "${ASIMOV_APP_SUPPORT}/*/*/extensions_crx_cache"
+    "${ASIMOV_APP_SUPPORT}/Spotify/PersistentCache"     # offline audio, refetched on demand
+    "${ASIMOV_APP_SUPPORT}/Google/Chrome/OptGuideOnDeviceModel"
+    "${ASIMOV_APP_SUPPORT}/Google/Chrome/OptGuideOnDeviceClassifierModel"
+    "${ASIMOV_APP_SUPPORT}/Google/Chrome/optimization_guide_model_store"
+    "${ASIMOV_APP_SUPPORT}/Arc/SidebarItemsFaviconCache"
+    "${ASIMOV_APP_SUPPORT}/Arc/ArchiveItemsFaviconCache"
+    "${ASIMOV_APP_SUPPORT}/Arc/ArchiveSnapshotCache"
+    "${ASIMOV_APP_SUPPORT}/Arc/BoostsImageCache"
+)
+
+# Expand one fixed-dir pattern into the directories that exist, one per line.
+#
+# Patterns without glob metacharacters keep the fast path (a single -d test), so
+# the common case pays nothing. When globbing is needed, IFS is cleared to switch
+# off word splitting while leaving pathname expansion active — without that, every
+# path containing a space ("Application Support") would shatter into fragments.
+expand_fixed_dir() {
+    local pattern="$1"
+
+    if [[ "$pattern" != *'*'* && "$pattern" != *'?'* && "$pattern" != *'['* ]]; then
+        [[ -d "$pattern" ]] && printf '%s\n' "$pattern"
+        return 0
+    fi
+
+    local nullglob_was_set=false
+    shopt -q nullglob && nullglob_was_set=true
+    shopt -s nullglob
+
+    local -a matches=()
+    local IFS=''
+    # shellcheck disable=SC2206  # deliberate: globbing with splitting disabled
+    matches=($pattern)
+
+    [[ "$nullglob_was_set" == false ]] && shopt -u nullglob
+
+    local match
+    for match in ${matches[@]+"${matches[@]}"}; do
+        [[ -d "$match" ]] && printf '%s\n' "$match"
+    done
+    return 0
+}
+
+# Expand every pattern in "$@" into ASIMOV_EXPANDED_DIRS (bash 3.2 has no
+# nameref, so the result is returned via a well-known global).
+expand_fixed_dirs() {
+    ASIMOV_EXPANDED_DIRS=()
+    local pattern path
+    for pattern in "$@"; do
+        while IFS= read -r path; do
+            [[ -n "$path" ]] && ASIMOV_EXPANDED_DIRS+=("$path")
+        done < <(expand_fixed_dir "$pattern")
+    done
+}
 
 # Record an excluded path: log for counting, compute size only with --stats.
 record_excluded_path() {
@@ -751,14 +860,16 @@ exclude_paths_from_stdin() {
     fi
     verbose_timing "Filtered: ${#to_exclude[@]} new, ${already_excluded} already excluded"
 
-    # Layer 2: Filter descendants of ASIMOV_FIXED_DIRS — they'll be excluded
+    # Layer 2: Filter descendants of the resolved fixed dirs — they'll be excluded
     # unconditionally later, so calling tmutil on them individually is wasted (~11s each).
-    if [[ "$ASIMOV_CONFIG_FIXED_DIRS_ENABLED" == "true" && ${#to_exclude[@]} -gt 0 ]]; then
+    # This must use the *expanded* list: a prefix compare against an unexpanded
+    # glob pattern would never match.
+    if [[ ${#ASIMOV_ALL_FIXED_DIRS[@]} -gt 0 && ${#to_exclude[@]} -gt 0 ]]; then
         local -a filtered_exclude=()
         for path in "${to_exclude[@]}"; do
             local under_fixed=false
             local fixed_dir
-            for fixed_dir in "${ASIMOV_FIXED_DIRS[@]}"; do
+            for fixed_dir in "${ASIMOV_ALL_FIXED_DIRS[@]}"; do
                 if [[ "$path" == "${fixed_dir}/"* ]]; then
                     under_fixed=true
                     break
@@ -975,6 +1086,96 @@ if [[ ! -d "$ASIMOV_ROOT" ]]; then
     exit 1
 fi
 
+# Decide whether application caches are excluded by default.
+#
+# New installs get them; anyone who already ran an earlier Asimov keeps the old
+# behaviour, so an upgrade never silently changes what gets excluded. The verdict
+# is written to ASIMOV_PROFILE_STATE on first run and honoured from then on, so
+# clearing the cache later can't flip it.
+#
+# Caveat: someone who only ever runs `asimov --no-cache` leaves no state at all
+# and is therefore indistinguishable from a new install.
+resolve_app_caches_default() {
+    if [[ -f "$ASIMOV_PROFILE_STATE" ]]; then
+        if grep -qx 'app_caches_default=false' "$ASIMOV_PROFILE_STATE" 2>/dev/null; then
+            echo false
+        else
+            echo true
+        fi
+        return 0
+    fi
+
+    if [[ "$ASIMOV_HAD_PRIOR_STATE" == true ]]; then
+        echo false
+    else
+        echo true
+    fi
+}
+
+# Persist the default so it survives a cache wipe. Skipped when the run is meant
+# to leave no trace (--dry-run, --no-write-cache).
+record_app_caches_default() {
+    local value="$1"
+    [[ -n "$ASIMOV_DRY_RUN" || -n "$ASIMOV_NO_WRITE_CACHE" ]] && return 0
+    [[ -f "$ASIMOV_PROFILE_STATE" ]] && return 0
+
+    local state_dir="${ASIMOV_PROFILE_STATE%/*}"
+    mkdir -p "$state_dir" 2>/dev/null || return 0
+    printf 'app_caches_default=%s\n' "$value" > "$ASIMOV_PROFILE_STATE" 2>/dev/null || return 0
+
+    # Match ensure_cache_dir: when running as root, leave the file owned by the
+    # console user so their next unprivileged run can still read it.
+    if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+        local console_user
+        console_user="$(stat -f '%Su' /dev/console 2>/dev/null || echo '')"
+        if [[ -n "$console_user" && "$console_user" != "root" ]]; then
+            chown -R "$console_user" "$state_dir" 2>/dev/null || true
+        fi
+    fi
+}
+
+app_caches_default="$(resolve_app_caches_default)"
+record_app_caches_default "$app_caches_default"
+
+# An explicit [app_caches] enabled always wins over the install profile.
+if [[ -n "$ASIMOV_CONFIG_APP_CACHES_ENABLED" ]]; then
+    ASIMOV_APP_CACHES_ENABLED="$ASIMOV_CONFIG_APP_CACHES_ENABLED"
+else
+    ASIMOV_APP_CACHES_ENABLED="$app_caches_default"
+fi
+readonly ASIMOV_APP_CACHES_ENABLED
+verbose_timing "App caches enabled: ${ASIMOV_APP_CACHES_ENABLED} (default ${app_caches_default})"
+
+# Expand every fixed-dir pattern up front. Done before find, because
+# exclude_paths_from_stdin's layer-2 filter compares candidate paths against these
+# and needs real directories rather than patterns.
+ASIMOV_EXPANDED_DIRS=()
+ASIMOV_BUILTIN_FIXED_DIRS=()
+ASIMOV_RESOLVED_APP_CACHE_DIRS=()
+ASIMOV_RESOLVED_EXTRA_DIRS=()
+
+if [[ "$ASIMOV_CONFIG_FIXED_DIRS_ENABLED" == "true" ]]; then
+    expand_fixed_dirs "${ASIMOV_FIXED_DIRS[@]}"
+    ASIMOV_BUILTIN_FIXED_DIRS=(${ASIMOV_EXPANDED_DIRS[@]+"${ASIMOV_EXPANDED_DIRS[@]}"})
+fi
+if [[ "$ASIMOV_APP_CACHES_ENABLED" == "true" ]]; then
+    expand_fixed_dirs "${ASIMOV_APP_CACHE_DIRS[@]}"
+    ASIMOV_RESOLVED_APP_CACHE_DIRS=(${ASIMOV_EXPANDED_DIRS[@]+"${ASIMOV_EXPANDED_DIRS[@]}"})
+fi
+if [[ ${#ASIMOV_CONFIG_EXTRA_FIXED_DIRS[@]} -gt 0 ]]; then
+    expand_fixed_dirs "${ASIMOV_CONFIG_EXTRA_FIXED_DIRS[@]}"
+    ASIMOV_RESOLVED_EXTRA_DIRS=(${ASIMOV_EXPANDED_DIRS[@]+"${ASIMOV_EXPANDED_DIRS[@]}"})
+fi
+
+# Combined view used by the layer-2 descendant filter.
+ASIMOV_ALL_FIXED_DIRS=(
+    ${ASIMOV_BUILTIN_FIXED_DIRS[@]+"${ASIMOV_BUILTIN_FIXED_DIRS[@]}"}
+    ${ASIMOV_RESOLVED_APP_CACHE_DIRS[@]+"${ASIMOV_RESOLVED_APP_CACHE_DIRS[@]}"}
+    ${ASIMOV_RESOLVED_EXTRA_DIRS[@]+"${ASIMOV_RESOLVED_EXTRA_DIRS[@]}"}
+)
+readonly -a ASIMOV_ALL_FIXED_DIRS
+verbose_timing "Fixed dirs resolved: ${#ASIMOV_ALL_FIXED_DIRS[@]} directories"
+
 # Determine whether to use the cache or do a full scan.
 # Cache is read when the cache file exists and reads aren't disabled
 # (--no-read-cache / --full-scan / --no-cache force a full scan).
@@ -1051,25 +1252,24 @@ else
 fi
 
 # Exclude built-in fixed dirs only when enabled via config.
-if [[ "$ASIMOV_CONFIG_FIXED_DIRS_ENABLED" == "true" ]]; then
+if [[ ${#ASIMOV_BUILTIN_FIXED_DIRS[@]} -gt 0 ]]; then
     [[ -z "$ASIMOV_QUIET" ]] && printf '\n%s💾 Excluding known cache directories…%s\n' \
         "$ASIMOV_COLOR_INFO" "$ASIMOV_COLOR_RESET"
-    for fixed_dir in "${ASIMOV_FIXED_DIRS[@]}"; do
-        if [[ -d "$fixed_dir" ]]; then
-            echo "$fixed_dir"
-        fi
-    done | exclude_paths_from_stdin
+    printf '%s\n' "${ASIMOV_BUILTIN_FIXED_DIRS[@]}" | exclude_paths_from_stdin
+fi
+
+# Exclude non-developer application caches (default on for new installs).
+if [[ ${#ASIMOV_RESOLVED_APP_CACHE_DIRS[@]} -gt 0 ]]; then
+    [[ -z "$ASIMOV_QUIET" ]] && printf '\n%s🧹 Excluding application caches…%s\n' \
+        "$ASIMOV_COLOR_INFO" "$ASIMOV_COLOR_RESET"
+    printf '%s\n' "${ASIMOV_RESOLVED_APP_CACHE_DIRS[@]}" | exclude_paths_from_stdin
 fi
 
 # Always process extra fixed dirs from config (user explicitly wants them).
-if [[ ${#ASIMOV_CONFIG_EXTRA_FIXED_DIRS[@]} -gt 0 ]]; then
+if [[ ${#ASIMOV_RESOLVED_EXTRA_DIRS[@]} -gt 0 ]]; then
     [[ -z "$ASIMOV_QUIET" ]] && printf '\n%s⚙️  Excluding user-configured directories…%s\n' \
         "$ASIMOV_COLOR_INFO" "$ASIMOV_COLOR_RESET"
-    for fixed_dir in "${ASIMOV_CONFIG_EXTRA_FIXED_DIRS[@]}"; do
-        if [[ -d "$fixed_dir" ]]; then
-            echo "$fixed_dir"
-        fi
-    done | exclude_paths_from_stdin
+    printf '%s\n' "${ASIMOV_RESOLVED_EXTRA_DIRS[@]}" | exclude_paths_from_stdin
 fi
 
 verbose_timing "All exclusions processed"

--- a/asimov
+++ b/asimov
@@ -823,16 +823,24 @@ expand_fixed_dir() {
     shopt -q nocaseglob && nocaseglob_was_set=true
     shopt -s nullglob nocaseglob
 
+    # Clear IFS for the expansion only, then put it back immediately. bash 3.2 is
+    # still the system bash on macOS, and it mangles an unquoted array expansion
+    # while IFS is empty: every element gets joined into one string. Restoring IFS
+    # before the array is read back keeps 3.2 and 5.x in agreement.
     local -a matches=()
-    local IFS=''
+    local saved_ifs="$IFS"
+    IFS=''
     # shellcheck disable=SC2206  # deliberate: globbing with splitting disabled
     matches=($pattern)
+    IFS="$saved_ifs"
 
     [[ "$nullglob_was_set" == false ]] && shopt -u nullglob
     [[ "$nocaseglob_was_set" == false ]] && shopt -u nocaseglob
 
+    [[ ${#matches[@]} -eq 0 ]] && return 0
+
     local match
-    for match in ${matches[@]+"${matches[@]}"}; do
+    for match in "${matches[@]}"; do
         [[ -d "$match" ]] && printf '%s\n' "$match"
     done
     return 0

--- a/asimov
+++ b/asimov
@@ -719,29 +719,80 @@ readonly ASIMOV_FIXED_DIRS=(
 # Machine, so anything under those is already handled — but Electron and Chromium
 # apps keep their caches in Application Support, which *is* backed up.
 #
-# Cache directory names appear both one and two levels down (e.g. Code/Cache and
-# Arc/User Data/Code Cache), and a glob does not cross a slash, so each name is
-# listed at both depths.
+# Cache directory names recur at several depths (Code/Cache, Arc/User Data/Code
+# Cache, Notion/Partitions/notion/Cache), and a glob does not cross a slash, so
+# each name is listed at every depth it is known to occur.
 readonly ASIMOV_APP_SUPPORT="${ASIMOV_ROOT}/Library/Application Support"
 readonly ASIMOV_APP_CACHE_DIRS=(
-    "${ASIMOV_APP_SUPPORT}/*/Cache"                     # Electron HTTP cache
-    "${ASIMOV_APP_SUPPORT}/*/*/Cache"
-    "${ASIMOV_APP_SUPPORT}/*/Code Cache"                # compiled-JS cache
+    # Electron and Chromium HTTP / compiled-JS / GPU caches.
+    #
+    # [Cc] on the names that vary in practice (Zed ships node/cache, Messenger
+    # ships crashpad, everyone else capitalises). A trailing literal component is
+    # only ever existence-tested, never globbed, so it would match nothing at all
+    # on a case-sensitive volume; a bracket makes it a real glob.
+    "${ASIMOV_APP_SUPPORT}/*/[Cc]ache"
+    "${ASIMOV_APP_SUPPORT}/*/*/[Cc]ache"
+    "${ASIMOV_APP_SUPPORT}/*/*/*/[Cc]ache"
+    "${ASIMOV_APP_SUPPORT}/[Cc]aches"
+    "${ASIMOV_APP_SUPPORT}/*/[Cc]aches"
+    "${ASIMOV_APP_SUPPORT}/*/Code Cache"
     "${ASIMOV_APP_SUPPORT}/*/*/Code Cache"
-    "${ASIMOV_APP_SUPPORT}/*/GPUCache"                  # shader cache
+    "${ASIMOV_APP_SUPPORT}/*/*/*/Code Cache"
+    "${ASIMOV_APP_SUPPORT}/*/GPUCache"
     "${ASIMOV_APP_SUPPORT}/*/*/GPUCache"
-    "${ASIMOV_APP_SUPPORT}/*/DawnWebGPUCache"           # WebGPU shader cache
+    "${ASIMOV_APP_SUPPORT}/*/*/*/GPUCache"
+
+    # Shader caches. Chromium has accumulated four of these over the years and
+    # still writes all of them.
+    "${ASIMOV_APP_SUPPORT}/*/DawnWebGPUCache"
     "${ASIMOV_APP_SUPPORT}/*/*/DawnWebGPUCache"
-    "${ASIMOV_APP_SUPPORT}/*/CachedData"                # VS Code-family V8 code cache
+    "${ASIMOV_APP_SUPPORT}/*/GraphiteDawnCache"
+    "${ASIMOV_APP_SUPPORT}/*/*/GraphiteDawnCache"
+    "${ASIMOV_APP_SUPPORT}/*/GrShaderCache"
+    "${ASIMOV_APP_SUPPORT}/*/*/GrShaderCache"
+    "${ASIMOV_APP_SUPPORT}/*/ShaderCache"
+    "${ASIMOV_APP_SUPPORT}/*/*/ShaderCache"
+
+    # VS Code family (Code, Cursor, VSCodium, Kiro, Antigravity, Windsurf …).
+    "${ASIMOV_APP_SUPPORT}/*/CachedData"                # V8 code cache
     "${ASIMOV_APP_SUPPORT}/*/CachedExtensionVSIXs"      # re-downloadable .vsix archives
-    "${ASIMOV_APP_SUPPORT}/*/component_crx_cache"       # Chromium component downloads
+    "${ASIMOV_APP_SUPPORT}/*/WebStorage/*/CacheStorage" # service-worker HTTP cache
+
+    # Chromium downloads: components, extensions, on-device models, blocklists.
+    # Globbed rather than named per browser, so Edge/Brave/Vivaldi/Chromium and
+    # the Chrome channels are covered without tracking each one.
+    "${ASIMOV_APP_SUPPORT}/*/component_crx_cache"
     "${ASIMOV_APP_SUPPORT}/*/*/component_crx_cache"
-    "${ASIMOV_APP_SUPPORT}/*/extensions_crx_cache"      # Chromium extension downloads
+    "${ASIMOV_APP_SUPPORT}/*/extensions_crx_cache"
     "${ASIMOV_APP_SUPPORT}/*/*/extensions_crx_cache"
+    "${ASIMOV_APP_SUPPORT}/*/OptGuideOnDevice*"
+    "${ASIMOV_APP_SUPPORT}/*/*/OptGuideOnDevice*"
+    "${ASIMOV_APP_SUPPORT}/*/optimization_guide*"
+    "${ASIMOV_APP_SUPPORT}/*/*/optimization_guide*"
+    "${ASIMOV_APP_SUPPORT}/*/Safe Browsing"
+    "${ASIMOV_APP_SUPPORT}/*/*/Safe Browsing"
+    "${ASIMOV_APP_SUPPORT}/*/WidevineCdm"               # DRM module, re-downloaded
+    "${ASIMOV_APP_SUPPORT}/*/*/WidevineCdm"
+
+    # Crash dumps awaiting upload, and Electron's transient blob spool.
+    "${ASIMOV_APP_SUPPORT}/*/[Cc]rashpad"
+    "${ASIMOV_APP_SUPPORT}/*/*/[Cc]rashpad"
+    "${ASIMOV_APP_SUPPORT}/*/Crash Reports"
+    "${ASIMOV_APP_SUPPORT}/*/blob_storage"
+    "${ASIMOV_APP_SUPPORT}/*/*/blob_storage"
+
+    # Downloaded app updates (Signal, Slack, Discord share this name).
+    "${ASIMOV_APP_SUPPORT}/*/update-cache"
+
+    # Vendor-specific caches that follow no shared convention.
     "${ASIMOV_APP_SUPPORT}/Spotify/PersistentCache"     # offline audio, refetched on demand
-    "${ASIMOV_APP_SUPPORT}/Google/Chrome/OptGuideOnDeviceModel"
-    "${ASIMOV_APP_SUPPORT}/Google/Chrome/OptGuideOnDeviceClassifierModel"
-    "${ASIMOV_APP_SUPPORT}/Google/Chrome/optimization_guide_model_store"
+    "${ASIMOV_APP_SUPPORT}/Google/GoogleUpdater/crx_cache"
+    "${ASIMOV_APP_SUPPORT}/Google/DriveFS/cef_cache"
+    "${ASIMOV_APP_SUPPORT}/Notion/notionAssetCache-v2"
+    "${ASIMOV_APP_SUPPORT}/Steam/appcache"
+    "${ASIMOV_APP_SUPPORT}/Steam/config/htmlcache"
+    "${ASIMOV_APP_SUPPORT}/Setapp/*/SetappIcons/*ImageCache*"
+    "${ASIMOV_APP_SUPPORT}/SketchUp*/WebCache-*"
     "${ASIMOV_APP_SUPPORT}/Arc/SidebarItemsFaviconCache"
     "${ASIMOV_APP_SUPPORT}/Arc/ArchiveItemsFaviconCache"
     "${ASIMOV_APP_SUPPORT}/Arc/ArchiveSnapshotCache"
@@ -754,6 +805,11 @@ readonly ASIMOV_APP_CACHE_DIRS=(
 # the common case pays nothing. When globbing is needed, IFS is cleared to switch
 # off word splitting while leaving pathname expansion active — without that, every
 # path containing a space ("Application Support") would shatter into fragments.
+#
+# Matching is case-insensitive (nocaseglob). Apps are inconsistent about it —
+# Zed ships node/cache while everyone else ships Cache — and that only goes
+# unnoticed because APFS is case-insensitive by default. On a case-sensitive
+# volume, a case-sensitive glob would silently match nothing.
 expand_fixed_dir() {
     local pattern="$1"
 
@@ -762,9 +818,10 @@ expand_fixed_dir() {
         return 0
     fi
 
-    local nullglob_was_set=false
+    local nullglob_was_set=false nocaseglob_was_set=false
     shopt -q nullglob && nullglob_was_set=true
-    shopt -s nullglob
+    shopt -q nocaseglob && nocaseglob_was_set=true
+    shopt -s nullglob nocaseglob
 
     local -a matches=()
     local IFS=''
@@ -772,6 +829,7 @@ expand_fixed_dir() {
     matches=($pattern)
 
     [[ "$nullglob_was_set" == false ]] && shopt -u nullglob
+    [[ "$nocaseglob_was_set" == false ]] && shopt -u nocaseglob
 
     local match
     for match in ${matches[@]+"${matches[@]}"}; do
@@ -1168,9 +1226,13 @@ if [[ ${#ASIMOV_CONFIG_EXTRA_FIXED_DIRS[@]} -gt 0 ]]; then
 fi
 
 # Combined view used by the layer-2 descendant filter.
+#
+# App-cache dirs are deliberately left out. That filter only ever sees candidates
+# produced by find or mdfind, and both skip ~/Library (ASIMOV_SKIP_PATHS), so an
+# app-cache dir can never be one of their ancestors. Including them would add a
+# few hundred no-hope string compares per candidate path.
 ASIMOV_ALL_FIXED_DIRS=(
     ${ASIMOV_BUILTIN_FIXED_DIRS[@]+"${ASIMOV_BUILTIN_FIXED_DIRS[@]}"}
-    ${ASIMOV_RESOLVED_APP_CACHE_DIRS[@]+"${ASIMOV_RESOLVED_APP_CACHE_DIRS[@]}"}
     ${ASIMOV_RESOLVED_EXTRA_DIRS[@]+"${ASIMOV_RESOLVED_EXTRA_DIRS[@]}"}
 )
 readonly -a ASIMOV_ALL_FIXED_DIRS
@@ -1259,10 +1321,14 @@ if [[ ${#ASIMOV_BUILTIN_FIXED_DIRS[@]} -gt 0 ]]; then
 fi
 
 # Exclude non-developer application caches (default on for new installs).
+# Patterns at several depths can match a directory and something inside it
+# (e.g. */Cache and */*/Cache), so drop nested paths first: a Time Machine
+# exclusion is recursive, and each redundant tmutil call costs ~11s.
 if [[ ${#ASIMOV_RESOLVED_APP_CACHE_DIRS[@]} -gt 0 ]]; then
     [[ -z "$ASIMOV_QUIET" ]] && printf '\n%s🧹 Excluding application caches…%s\n' \
         "$ASIMOV_COLOR_INFO" "$ASIMOV_COLOR_RESET"
-    printf '%s\n' "${ASIMOV_RESOLVED_APP_CACHE_DIRS[@]}" | exclude_paths_from_stdin
+    printf '%s\n' "${ASIMOV_RESOLVED_APP_CACHE_DIRS[@]}" \
+        | sort -u | dedup_nested_paths | exclude_paths_from_stdin
 fi
 
 # Always process extra fixed dirs from config (user explicitly wants them).

--- a/tests/behavior.bats
+++ b/tests/behavior.bats
@@ -898,3 +898,125 @@ enabled = false"
   run_asimov --full-scan
   refute_excluded "${HOME}/Library/Application Support/Spotify/PersistentCache"
 }
+
+# =============================================================================
+# Application caches: depth, case, and named cache types
+# =============================================================================
+
+@test "app caches: matches a named cache three levels below Application Support" {
+  # Notion, Figma and Cursor nest caches under a Partitions/profile directory.
+  create_app_support_dir "Notion/Partitions/notion/Cache"
+  create_app_support_dir "Figma/DesktopProfile/v20/Code Cache"
+  run_asimov
+  assert_excluded "${HOME}/Library/Application Support/Notion/Partitions/notion/Cache"
+  assert_excluded "${HOME}/Library/Application Support/Figma/DesktopProfile/v20/Code Cache"
+}
+
+@test "app caches: matches a lowercase cache directory" {
+  # Zed ships node/cache; most apps ship Cache. Only nocaseglob catches both on a
+  # case-sensitive volume.
+  create_app_support_dir "Zed/node/cache"
+  run_asimov
+  assert_excluded "${HOME}/Library/Application Support/Zed/node/cache"
+}
+
+@test "app caches: matches all four Chromium shader caches" {
+  create_app_support_dir "Chromium/GraphiteDawnCache"
+  create_app_support_dir "Chromium/GrShaderCache"
+  create_app_support_dir "Chromium/ShaderCache"
+  create_app_support_dir "Chromium/DawnWebGPUCache"
+  run_asimov
+  assert_excluded "${HOME}/Library/Application Support/Chromium/GraphiteDawnCache"
+  assert_excluded "${HOME}/Library/Application Support/Chromium/GrShaderCache"
+  assert_excluded "${HOME}/Library/Application Support/Chromium/ShaderCache"
+  assert_excluded "${HOME}/Library/Application Support/Chromium/DawnWebGPUCache"
+}
+
+@test "app caches: matches on-device model stores for any Chromium browser" {
+  create_app_support_dir "Microsoft Edge/OptGuideOnDeviceModel"
+  create_app_support_dir "BraveSoftware/Brave-Browser/optimization_guide_model_store"
+  run_asimov
+  assert_excluded "${HOME}/Library/Application Support/Microsoft Edge/OptGuideOnDeviceModel"
+  assert_excluded "${HOME}/Library/Application Support/BraveSoftware/Brave-Browser/optimization_guide_model_store"
+}
+
+@test "app caches: matches the service-worker cache inside VS Code-family editors" {
+  create_app_support_dir "Cursor/WebStorage/1/CacheStorage"
+  run_asimov
+  assert_excluded "${HOME}/Library/Application Support/Cursor/WebStorage/1/CacheStorage"
+}
+
+@test "app caches: leaves the WebStorage parent alone" {
+  # WebStorage itself holds localStorage; only its CacheStorage child is cache.
+  create_app_support_dir "Cursor/WebStorage/1/CacheStorage"
+  run_asimov
+  refute_excluded "${HOME}/Library/Application Support/Cursor/WebStorage"
+  refute_excluded "${HOME}/Library/Application Support/Cursor/WebStorage/1"
+}
+
+@test "app caches: matches crash dumps and transient blob spools" {
+  create_app_support_dir "Lens/Crashpad"
+  create_app_support_dir "Messenger/crashpad"
+  create_app_support_dir "Firefox/Crash Reports"
+  create_app_support_dir "Slack/blob_storage"
+  run_asimov
+  assert_excluded "${HOME}/Library/Application Support/Lens/Crashpad"
+  assert_excluded "${HOME}/Library/Application Support/Messenger/crashpad"
+  assert_excluded "${HOME}/Library/Application Support/Firefox/Crash Reports"
+  assert_excluded "${HOME}/Library/Application Support/Slack/blob_storage"
+}
+
+@test "app caches: matches downloadable modules and blocklists" {
+  create_app_support_dir "Vivaldi/WidevineCdm"
+  create_app_support_dir "Google/Chrome/Safe Browsing"
+  create_app_support_dir "Signal/update-cache"
+  run_asimov
+  assert_excluded "${HOME}/Library/Application Support/Vivaldi/WidevineCdm"
+  assert_excluded "${HOME}/Library/Application Support/Google/Chrome/Safe Browsing"
+  assert_excluded "${HOME}/Library/Application Support/Signal/update-cache"
+}
+
+@test "app caches: matches a literal Caches directory" {
+  create_app_support_dir "Caches"
+  create_app_support_dir "SomeApp/Caches"
+  run_asimov
+  assert_excluded "${HOME}/Library/Application Support/Caches"
+  assert_excluded "${HOME}/Library/Application Support/SomeApp/Caches"
+}
+
+@test "app caches: matches the vendor-specific caches" {
+  create_app_support_dir "Google/GoogleUpdater/crx_cache"
+  create_app_support_dir "Google/DriveFS/cef_cache"
+  create_app_support_dir "Notion/notionAssetCache-v2"
+  create_app_support_dir "Steam/appcache"
+  create_app_support_dir "Steam/config/htmlcache"
+  create_app_support_dir "Setapp/Default/SetappIcons/com.onevcat.Kingfisher.ImageCache.setapp"
+  create_app_support_dir "SketchUp 2026/WebCache-137.0.7151.121"
+  run_asimov
+  assert_excluded "${HOME}/Library/Application Support/Google/GoogleUpdater/crx_cache"
+  assert_excluded "${HOME}/Library/Application Support/Google/DriveFS/cef_cache"
+  assert_excluded "${HOME}/Library/Application Support/Notion/notionAssetCache-v2"
+  assert_excluded "${HOME}/Library/Application Support/Steam/appcache"
+  assert_excluded "${HOME}/Library/Application Support/Steam/config/htmlcache"
+  assert_excluded "${HOME}/Library/Application Support/Setapp/Default/SetappIcons/com.onevcat.Kingfisher.ImageCache.setapp"
+  assert_excluded "${HOME}/Library/Application Support/SketchUp 2026/WebCache-137.0.7151.121"
+}
+
+@test "app caches: a nested match is excluded only once, via its ancestor" {
+  # */Cache and */*/Cache can both match when one nests inside the other.
+  # Time Machine exclusions are recursive, so only the ancestor is worth a call.
+  create_app_support_dir "App/Cache/inner/Cache"
+  run_asimov
+  assert_excluded "${HOME}/Library/Application Support/App/Cache"
+  refute_excluded "${HOME}/Library/Application Support/App/Cache/inner/Cache"
+  [[ "$(count_exclusions)" -eq 1 ]]
+}
+
+@test "app caches: nothing outside Application Support is touched" {
+  # Deliberately scoped: ~/Library/Unity/cache and ~/Library/Mail caches are not ours.
+  mkdir -p "${HOME}/Library/Unity/cache"
+  mkdir -p "${HOME}/Library/Mail/V10/MailData/RemoteContentURLCache"
+  run_asimov
+  refute_excluded "${HOME}/Library/Unity/cache"
+  refute_excluded "${HOME}/Library/Mail/V10/MailData/RemoteContentURLCache"
+}

--- a/tests/behavior.bats
+++ b/tests/behavior.bats
@@ -734,3 +734,167 @@ extra = ${HOME}/Code"
   [[ "$(count_exclusions)" -eq 1 ]]
   refute_excluded "${HOME}/Projects/app/node_modules"
 }
+
+# =============================================================================
+# Glob support in fixed directories
+# =============================================================================
+
+@test "fixed dirs: extra path expands a glob" {
+  mkdir -p "${HOME}/builds/alpha/dist"
+  mkdir -p "${HOME}/builds/beta/dist"
+  write_config "[fixed_dirs]
+extra = ~/builds/*/dist"
+
+  run_asimov
+
+  assert_excluded "${HOME}/builds/alpha/dist"
+  assert_excluded "${HOME}/builds/beta/dist"
+}
+
+@test "fixed dirs: glob expansion keeps paths containing spaces intact" {
+  mkdir -p "${HOME}/Application Support/My App/Code Cache"
+  write_config "[fixed_dirs]
+extra = ~/Application Support/*/Code Cache"
+
+  run_asimov
+
+  assert_excluded "${HOME}/Application Support/My App/Code Cache"
+}
+
+@test "fixed dirs: glob matching nothing is not an error" {
+  write_config "[fixed_dirs]
+extra = ~/nowhere/*/dist"
+
+  run_asimov
+
+  [[ "$status" -eq 0 ]]
+  [[ "$(count_exclusions)" -eq 0 ]]
+}
+
+@test "fixed dirs: glob only matches directories, not files" {
+  mkdir -p "${HOME}/builds/alpha"
+  touch "${HOME}/builds/alpha/dist"
+  write_config "[fixed_dirs]
+extra = ~/builds/*/dist"
+
+  run_asimov
+
+  [[ "$status" -eq 0 ]]
+  refute_excluded "${HOME}/builds/alpha/dist"
+}
+
+# =============================================================================
+# Application caches
+# =============================================================================
+
+# Create a directory under ~/Library/Application Support.
+create_app_support_dir() {
+  mkdir -p "${HOME}/Library/Application Support/$1"
+}
+
+# Simulate a machine that has already run an earlier version of Asimov.
+simulate_prior_install() {
+  mkdir -p "${HOME}/.cache/asimov"
+  echo "${HOME}/some/old/path" > "${HOME}/.cache/asimov/excluded"
+}
+
+@test "app caches: excluded by default on a new install" {
+  create_app_support_dir "Spotify/PersistentCache"
+  run_asimov
+  assert_excluded "${HOME}/Library/Application Support/Spotify/PersistentCache"
+}
+
+@test "app caches: matches a named cache one level below Application Support" {
+  create_app_support_dir "discord/Cache"
+  create_app_support_dir "Code/CachedExtensionVSIXs"
+  run_asimov
+  assert_excluded "${HOME}/Library/Application Support/discord/Cache"
+  assert_excluded "${HOME}/Library/Application Support/Code/CachedExtensionVSIXs"
+}
+
+@test "app caches: matches a named cache two levels below Application Support" {
+  create_app_support_dir "Arc/User Data/Code Cache"
+  create_app_support_dir "Google/Chrome/component_crx_cache"
+  run_asimov
+  assert_excluded "${HOME}/Library/Application Support/Arc/User Data/Code Cache"
+  assert_excluded "${HOME}/Library/Application Support/Google/Chrome/component_crx_cache"
+}
+
+@test "app caches: leaves non-cache directories alone" {
+  create_app_support_dir "Code/User"
+  create_app_support_dir "Google/Chrome/Default"
+  run_asimov
+  refute_excluded "${HOME}/Library/Application Support/Code/User"
+  refute_excluded "${HOME}/Library/Application Support/Google/Chrome/Default"
+}
+
+@test "app caches: not excluded when the machine has prior Asimov state" {
+  simulate_prior_install
+  create_app_support_dir "Spotify/PersistentCache"
+  run_asimov
+  refute_excluded "${HOME}/Library/Application Support/Spotify/PersistentCache"
+}
+
+@test "app caches: existing user can opt in explicitly" {
+  simulate_prior_install
+  create_app_support_dir "Spotify/PersistentCache"
+  write_config "[app_caches]
+enabled = true"
+  run_asimov
+  assert_excluded "${HOME}/Library/Application Support/Spotify/PersistentCache"
+}
+
+@test "app caches: new install can opt out explicitly" {
+  create_app_support_dir "Spotify/PersistentCache"
+  write_config "[app_caches]
+enabled = false"
+  run_asimov
+  refute_excluded "${HOME}/Library/Application Support/Spotify/PersistentCache"
+}
+
+@test "app caches: first run records the resolved default" {
+  run_asimov
+  [[ -f "${HOME}/.local/state/asimov/profile" ]]
+  grep -qx 'app_caches_default=true' "${HOME}/.local/state/asimov/profile"
+}
+
+@test "app caches: an upgrader's recorded default is off" {
+  simulate_prior_install
+  run_asimov
+  grep -qx 'app_caches_default=false' "${HOME}/.local/state/asimov/profile"
+}
+
+@test "app caches: recorded default survives a cache wipe" {
+  # Existing user: default resolves to off and is recorded.
+  simulate_prior_install
+  run_asimov
+  grep -qx 'app_caches_default=false' "${HOME}/.local/state/asimov/profile"
+
+  # Wiping the cache would otherwise make them look like a new install.
+  rm -rf "${HOME}/.cache/asimov"
+  create_app_support_dir "Spotify/PersistentCache"
+  run_asimov
+
+  refute_excluded "${HOME}/Library/Application Support/Spotify/PersistentCache"
+}
+
+@test "app caches: dry-run does not record a default" {
+  run_asimov --dry-run
+  [[ "$status" -eq 0 ]]
+  [[ ! -f "${HOME}/.local/state/asimov/profile" ]]
+}
+
+@test "app caches: --no-write-cache does not record a default" {
+  run_asimov --no-write-cache
+  [[ "$status" -eq 0 ]]
+  [[ ! -f "${HOME}/.local/state/asimov/profile" ]]
+}
+
+@test "app caches: a full scan by an existing user still counts as an upgrade" {
+  # --no-read-cache clears the state files, so the prior-install signal must be
+  # captured before that happens.
+  simulate_prior_install
+  create_app_support_dir "Spotify/PersistentCache"
+  run_asimov --full-scan
+  refute_excluded "${HOME}/Library/Application Support/Spotify/PersistentCache"
+}

--- a/tests/behavior.bats
+++ b/tests/behavior.bats
@@ -1020,3 +1020,24 @@ enabled = false"
   refute_excluded "${HOME}/Library/Unity/cache"
   refute_excluded "${HOME}/Library/Mail/V10/MailData/RemoteContentURLCache"
 }
+
+@test "fixed dirs: glob expansion works under bash 3.2 (the system bash)" {
+  # asimov ships with #!/usr/bin/env bash, so on a stock Mac it runs under bash
+  # 3.2. bash 3.2 joins the elements of an unquoted array expansion while IFS is
+  # empty, which silently reduced every multi-match glob to nothing. The local
+  # suite runs under whatever bash is first on PATH, so this asserts 3.2 directly.
+  [[ -x /bin/bash ]] || skip "no /bin/bash available"
+  mkdir -p "${HOME}/builds/alpha/dist" "${HOME}/builds/beta/dist" "${HOME}/app/Code Cache"
+
+  run /bin/bash -c '
+    set -Eeu -o pipefail
+    eval "$(awk "/^expand_fixed_dir\(\)/,/^}/" "$1")"
+    expand_fixed_dir "$2/builds/*/dist"
+    expand_fixed_dir "$2/*/Code Cache"
+  ' _ "${BATS_TEST_DIRNAME}/../asimov" "$HOME"
+
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"${HOME}/builds/alpha/dist"* ]]
+  [[ "$output" == *"${HOME}/builds/beta/dist"* ]]
+  [[ "$output" == *"${HOME}/app/Code Cache"* ]]
+}


### PR DESCRIPTION
Closes #39.

macOS already keeps `~/Library/Caches`, `~/Library/Logs` and `~/Library/Containers` out of Time Machine. What it does **not** keep out is `~/Library/Application Support`, and that is exactly where Electron and Chromium apps put their caches. This PR excludes those.

Measured on one everyday Mac: **18 GB across 361 directories.**

## Feedback wanted

This goes beyond "development dependencies", which is the scope Asimov has always had. Steve flagged that tension back in #39 and it is still the right question, so I would rather get it wrong in public than merge it quietly. Specifically:

1. **Does this belong in Asimov at all**, or is it a separate tool? The counter-argument: the mechanism is identical, the audience overlaps almost entirely, and nobody wants two launchd jobs walking their home directory.
2. **Is anything in the list not actually a cache?** I have tried to keep this to things that are purely derived and refetchable, but I only have my own Mac to look at. If one of these holds something you would miss after a restore, say so and it comes out.
3. **Is the default right?** See below.
4. **What is missing?** Especially for apps and browsers I do not run.

## The default

On by default for **new installs only**. If you already run Asimov, nothing changes until you opt in:

```ini
[app_caches]
enabled = true      # existing users: opt in
enabled = false     # new installs: opt out
```

An upgrade silently changing what leaves your backups is not acceptable, so the decision is resolved once from whether `~/.cache/asimov` state already exists, then recorded in `~/.local/state/asimov/profile` (outside the cache, so clearing the cache cannot flip it). Known gap: someone who only ever runs `asimov --no-cache` leaves no state and is indistinguishable from a new install.

## What is excluded

**Generic Electron and Chromium**, globbed at every depth they occur (`App/Cache`, `Arc/User Data/Code Cache`, `Notion/Partitions/notion/Cache`):

`Cache`, `Caches`, `Code Cache`, `GPUCache`, the four Chromium shader caches (`DawnWebGPUCache`, `GraphiteDawnCache`, `GrShaderCache`, `ShaderCache`), `CachedData`, `CachedExtensionVSIXs`, `WebStorage/*/CacheStorage`, `component_crx_cache`, `extensions_crx_cache`, `OptGuideOnDevice*`, `optimization_guide*`, `Safe Browsing`, `WidevineCdm`, `Crashpad`, `Crash Reports`, `blob_storage`, `update-cache`

**Vendor-specific**: Spotify `PersistentCache` (the original request in #39), Google Updater `crx_cache` (812 MB here, the largest single entry), Notion's asset cache, Google Drive `cef_cache`, Steam `appcache` and `htmlcache`, Setapp's icon cache, SketchUp's versioned web cache, Arc's four favicon and snapshot caches.

**Deliberately not included**: anything under `~/Library` outside `Application Support`, and anything holding real state. `IndexedDB`, `Local Storage`, `WebStorage` itself, `User/globalStorage` and `User/workspaceStorage` are all cache-shaped names over user data and are left alone.

## Implementation notes

Fixed-directory paths now support globs, which the per-app and per-profile layouts require. Two details worth reviewing:

- Expansion uses `nullglob` with `IFS` cleared, so word splitting is off while pathname expansion still runs. Without that, every path containing `Application Support` shatters on the space.
- Names that vary in case are bracketed (`[Cc]ache`, `[Cc]rashpad`). A trailing **literal** path component is only ever existence-tested, never globbed, so on a case-sensitive volume it would match nothing at all. Zed ships `node/cache`; Messenger ships `crashpad`.

Patterns are expanded once before `find`, because the layer-2 descendant filter prefix-compares against them and would never match an unexpanded pattern. Resolved app-cache paths are then dropped from that filter: it only ever sees `find`/`mdfind` candidates, and both skip `~/Library`, so those compares could never hit. The app-cache pass dedupes nested paths, since patterns at different depths can match both a directory and something inside it, and a redundant `tmutil` call costs ~11s.

## Tests

30 new Bats tests covering glob expansion (including paths with spaces, non-matching globs, files vs directories), each cache family, the depth and case handling, the nesting dedup, the default-on/default-off resolution, profile persistence across a cache wipe, and both opt-in and opt-out.

One bug worth flagging, since it is a whole class of problem: the first CI run failed while `make check` passed locally. asimov ships with `#!/usr/bin/env bash`, so on a stock Mac it runs under **bash 3.2**, but a dev machine usually has bash 5 earlier on `PATH`. bash 3.2 joins the elements of an unquoted array expansion while `IFS` is empty, so `${matches[@]+"${matches[@]}"}` collapsed every match into one string and any glob with **more than one match** expanded to nothing. Single-match globs worked, which is exactly why it looked fine locally. Fixed, with a regression test that invokes `expand_fixed_dir` under `/bin/bash` directly.

`make check` passes: 202 tests, shellcheck clean, CI green on macos-14 and macos-15.

**Mergeable independently of 110.** That PR adds service-worker caches and touches the same array, so whichever lands second needs a trivial rebase.
