### PR TITLE
feat(app-caches): exclude service-worker caches and Claude vm_bundles (RFC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   most users get — `asimov` starts with `#!/usr/bin/env bash`, and a development machine
   usually has 5.x first on `PATH`. `make test BASH_BIN=<path>` pins any interpreter, and
   `make test BATS_JOBS=N` runs tests concurrently (needs GNU parallel).
+- Application cache exclusions: Spotify's offline storage, Chrome's on-device model stores,
+  and the `Cache` / `Code Cache` / `GPUCache` / `CachedData` / `CachedExtensionVSIXs` /
+  `*_crx_cache` directories that Electron and Chromium apps keep in
+  `~/Library/Application Support` (which, unlike `~/Library/Caches`, Time Machine does back up).
+  Enabled by default on new installs and off for anyone upgrading; controlled by
+  `[app_caches] enabled`. Resolves [#39](https://github.com/AsimovMac/asimov/issues/39).
+- Fixed-directory paths now support globs (`*`, `?`, `[...]`), both in the built-in lists and
+  in `[fixed_dirs] extra` — including paths that contain spaces.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   `[app_caches] enabled`. Resolves [#39](https://github.com/AsimovMac/asimov/issues/39).
 - Fixed-directory paths now support globs (`*`, `?`, `[...]`), both in the built-in lists and
   in `[fixed_dirs] extra` — including paths that contain spaces.
+- Service-worker caches (`Service Worker/CacheStorage` and `Service Worker/ScriptCache`) and
+  Claude Desktop's `vm_bundles` sandbox images are now part of the application-cache set,
+  measured at 12.6 GB across 32 directories on one everyday Mac. The sibling
+  `Service Worker/Database`, which holds the worker registrations, is deliberately left
+  backed up.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,11 @@ macOS already keeps `~/Library/Caches` out of Time Machine — but Electron and 
 store their caches in `~/Library/Application Support`, which *is* backed up. Asimov excludes
 those too: Spotify's offline audio, Chrome's on-device model store, and the
 `Cache` / `Code Cache` / `GPUCache` / `CachedExtensionVSIXs` directories that every
-Electron app leaves behind. On one everyday Mac this came to 14 GB.
+Electron app leaves behind, plus service-worker caches. On one everyday Mac this came to 27 GB.
+
+Service-worker caches are handled carefully: `CacheStorage` and `ScriptCache` are excluded
+because both refetch from origin, while the `Database` beside them, which holds the worker
+registrations, stays backed up. Losing that is what logs you out of a web app.
 
 This is **on by default for new installs only**. If you were already running Asimov before
 this landed, nothing changes until you ask for it:

--- a/README.md
+++ b/README.md
@@ -178,6 +178,28 @@ Global tool caches in your home directory (`~/.cache`, `~/.gradle/caches`, …) 
 enabled = true                   # exclude the built-in global caches
 extra   = ~/my-build-cache       # plus any paths you name (always excluded when they exist)
 extra   = ~/golang/pkg/mod       # e.g. a Go module cache under a custom GOPATH
+extra   = ~/builds/*/dist        # globs work, including in paths containing spaces
+```
+
+### Application caches
+
+macOS already keeps `~/Library/Caches` out of Time Machine — but Electron and Chromium apps
+store their caches in `~/Library/Application Support`, which *is* backed up. Asimov excludes
+those too: Spotify's offline audio, Chrome's on-device model store, and the
+`Cache` / `Code Cache` / `GPUCache` / `CachedExtensionVSIXs` directories that every
+Electron app leaves behind. On one everyday Mac this came to 14 GB.
+
+This is **on by default for new installs only**. If you were already running Asimov before
+this landed, nothing changes until you ask for it:
+
+```ini
+[app_caches]
+enabled = true                   # existing users: opt in
+```
+
+```ini
+[app_caches]
+enabled = false                  # new installs: opt out
 ```
 
 ## Other install methods

--- a/asimov
+++ b/asimov
@@ -746,6 +746,21 @@ readonly ASIMOV_APP_CACHE_DIRS=(
     "${ASIMOV_APP_SUPPORT}/Arc/ArchiveItemsFaviconCache"
     "${ASIMOV_APP_SUPPORT}/Arc/ArchiveSnapshotCache"
     "${ASIMOV_APP_SUPPORT}/Arc/BoostsImageCache"
+
+    # Service-worker caches. Deliberately narrow: CacheStorage is an HTTP cache by
+    # specification, and ScriptCache holds copies of the worker scripts, so both
+    # refetch from origin. Their sibling Database/ holds the worker registrations
+    # and is NOT excluded — losing that is what logs you out of a web app or drops
+    # its offline mode, and it is tiny anyway.
+    "${ASIMOV_APP_SUPPORT}/*/Service Worker/CacheStorage"
+    "${ASIMOV_APP_SUPPORT}/*/*/Service Worker/CacheStorage"
+    "${ASIMOV_APP_SUPPORT}/*/*/*/Service Worker/CacheStorage"
+    "${ASIMOV_APP_SUPPORT}/*/Service Worker/ScriptCache"
+    "${ASIMOV_APP_SUPPORT}/*/*/Service Worker/ScriptCache"
+    "${ASIMOV_APP_SUPPORT}/*/*/*/Service Worker/ScriptCache"
+
+    # Claude Desktop's sandbox images, rebuilt on demand.
+    "${ASIMOV_APP_SUPPORT}/Claude/vm_bundles"
 )
 
 # Expand one fixed-dir pattern into the directories that exist, one per line.

--- a/asimov
+++ b/asimov
@@ -54,6 +54,12 @@ print_usage() {
     printf '\n'
     printf '  [scan]\n'
     printf '  extra = /private/var/www\n'
+    printf '\n'
+    printf 'Application caches (Spotify, Electron apps, browser model stores) are excluded\n'
+    printf 'by default on new installs. Turn them off with:\n'
+    printf '\n'
+    printf '  [app_caches]\n'
+    printf '  enabled = false\n'
 }
 
 # Parse options (before we need ASIMOV_ROOT).
@@ -152,12 +158,30 @@ readonly ASIMOV_EXCLUDED_STATE="${ASIMOV_ROOT}/.cache/asimov/excluded"
 readonly ASIMOV_FAILED_STATE="${ASIMOV_ROOT}/.cache/asimov/failed"
 readonly ASIMOV_MDFIND_SEEN="${ASIMOV_ROOT}/.cache/asimov/mdfind_seen"
 
+# Durable record of which defaults this installation was set up with. Lives in
+# ~/.local/state (not ~/.cache) precisely because it must survive a cache wipe.
+readonly ASIMOV_PROFILE_STATE="${ASIMOV_ROOT}/.local/state/asimov/profile"
+
+# Note whether this machine carries state from an earlier Asimov run. Computed
+# here, before the --no-read-cache branch below deletes any of it — otherwise an
+# upgrader whose first run is --full-scan would look like a brand-new install and
+# silently pick up new defaults.
+if [[ -e "$ASIMOV_EXCLUDED_STATE" || -e "$ASIMOV_FAILED_STATE" \
+   || -e "$ASIMOV_MDFIND_SEEN" || -e "${ASIMOV_ROOT}/.cache/asimov/paths" ]]; then
+    readonly ASIMOV_HAD_PRIOR_STATE=true
+else
+    readonly ASIMOV_HAD_PRIOR_STATE=false
+fi
+
 # Load optional config from ~/.config/asimov/config.
 # Populates ASIMOV_CONFIG_* variables. Missing file is silently ignored.
 load_config() {
     local config_file="${ASIMOV_ROOT}/.config/asimov/config"
 
     ASIMOV_CONFIG_FIXED_DIRS_ENABLED=false
+    # Empty means "not set" — the default is resolved later from the install
+    # profile, so we must be able to tell an absent key from an explicit false.
+    ASIMOV_CONFIG_APP_CACHES_ENABLED=''
     ASIMOV_CONFIG_EXTRA_FIXED_DIRS=()
     ASIMOV_CONFIG_EXTRA_SENTINELS=()
     ASIMOV_CONFIG_DISABLED_SENTINELS=()
@@ -189,6 +213,9 @@ load_config() {
                 fixed_dirs:extra)
                     value="${value/#\~/$HOME}"
                     ASIMOV_CONFIG_EXTRA_FIXED_DIRS+=("$value")
+                    ;;
+                app_caches:enabled)
+                    ASIMOV_CONFIG_APP_CACHES_ENABLED="$value"
                     ;;
                 scan:extra)
                     value="${value/#\~/$HOME}"
@@ -671,6 +698,8 @@ readonly ASIMOV_VENDOR_DIR_SENTINELS=(
 # Unlike sentinel-based pairs above, these directories are always excluded
 # when they exist — they represent global tool caches and artifacts that
 # can be safely restored.
+#
+# Entries may contain glob metacharacters (*, ?, [...]); see expand_fixed_dir.
 readonly ASIMOV_FIXED_DIRS=(
     "${ASIMOV_ROOT}/.cache"                           # XDG cache directory
     "${ASIMOV_ROOT}/.gradle/caches"                   # Gradle download cache
@@ -682,6 +711,86 @@ readonly ASIMOV_FIXED_DIRS=(
     "${ASIMOV_ROOT}/.kube/http-cache"                 # Kubernetes HTTP cache
     "${ASIMOV_ROOT}/go/pkg/mod"                       # Go module cache (0555 inside; exclude as a whole)
 )
+
+# Non-developer application caches, controlled by [app_caches] enabled.
+#
+# Only ~/Library/Application Support is worth listing here. macOS already excludes
+# ~/Library/Caches, ~/Library/Logs, ~/Library/Containers and ~/.Trash from Time
+# Machine, so anything under those is already handled — but Electron and Chromium
+# apps keep their caches in Application Support, which *is* backed up.
+#
+# Cache directory names appear both one and two levels down (e.g. Code/Cache and
+# Arc/User Data/Code Cache), and a glob does not cross a slash, so each name is
+# listed at both depths.
+readonly ASIMOV_APP_SUPPORT="${ASIMOV_ROOT}/Library/Application Support"
+readonly ASIMOV_APP_CACHE_DIRS=(
+    "${ASIMOV_APP_SUPPORT}/*/Cache"                     # Electron HTTP cache
+    "${ASIMOV_APP_SUPPORT}/*/*/Cache"
+    "${ASIMOV_APP_SUPPORT}/*/Code Cache"                # compiled-JS cache
+    "${ASIMOV_APP_SUPPORT}/*/*/Code Cache"
+    "${ASIMOV_APP_SUPPORT}/*/GPUCache"                  # shader cache
+    "${ASIMOV_APP_SUPPORT}/*/*/GPUCache"
+    "${ASIMOV_APP_SUPPORT}/*/DawnWebGPUCache"           # WebGPU shader cache
+    "${ASIMOV_APP_SUPPORT}/*/*/DawnWebGPUCache"
+    "${ASIMOV_APP_SUPPORT}/*/CachedData"                # VS Code-family V8 code cache
+    "${ASIMOV_APP_SUPPORT}/*/CachedExtensionVSIXs"      # re-downloadable .vsix archives
+    "${ASIMOV_APP_SUPPORT}/*/component_crx_cache"       # Chromium component downloads
+    "${ASIMOV_APP_SUPPORT}/*/*/component_crx_cache"
+    "${ASIMOV_APP_SUPPORT}/*/extensions_crx_cache"      # Chromium extension downloads
+    "${ASIMOV_APP_SUPPORT}/*/*/extensions_crx_cache"
+    "${ASIMOV_APP_SUPPORT}/Spotify/PersistentCache"     # offline audio, refetched on demand
+    "${ASIMOV_APP_SUPPORT}/Google/Chrome/OptGuideOnDeviceModel"
+    "${ASIMOV_APP_SUPPORT}/Google/Chrome/OptGuideOnDeviceClassifierModel"
+    "${ASIMOV_APP_SUPPORT}/Google/Chrome/optimization_guide_model_store"
+    "${ASIMOV_APP_SUPPORT}/Arc/SidebarItemsFaviconCache"
+    "${ASIMOV_APP_SUPPORT}/Arc/ArchiveItemsFaviconCache"
+    "${ASIMOV_APP_SUPPORT}/Arc/ArchiveSnapshotCache"
+    "${ASIMOV_APP_SUPPORT}/Arc/BoostsImageCache"
+)
+
+# Expand one fixed-dir pattern into the directories that exist, one per line.
+#
+# Patterns without glob metacharacters keep the fast path (a single -d test), so
+# the common case pays nothing. When globbing is needed, IFS is cleared to switch
+# off word splitting while leaving pathname expansion active — without that, every
+# path containing a space ("Application Support") would shatter into fragments.
+expand_fixed_dir() {
+    local pattern="$1"
+
+    if [[ "$pattern" != *'*'* && "$pattern" != *'?'* && "$pattern" != *'['* ]]; then
+        [[ -d "$pattern" ]] && printf '%s\n' "$pattern"
+        return 0
+    fi
+
+    local nullglob_was_set=false
+    shopt -q nullglob && nullglob_was_set=true
+    shopt -s nullglob
+
+    local -a matches=()
+    local IFS=''
+    # shellcheck disable=SC2206  # deliberate: globbing with splitting disabled
+    matches=($pattern)
+
+    [[ "$nullglob_was_set" == false ]] && shopt -u nullglob
+
+    local match
+    for match in ${matches[@]+"${matches[@]}"}; do
+        [[ -d "$match" ]] && printf '%s\n' "$match"
+    done
+    return 0
+}
+
+# Expand every pattern in "$@" into ASIMOV_EXPANDED_DIRS (bash 3.2 has no
+# nameref, so the result is returned via a well-known global).
+expand_fixed_dirs() {
+    ASIMOV_EXPANDED_DIRS=()
+    local pattern path
+    for pattern in "$@"; do
+        while IFS= read -r path; do
+            [[ -n "$path" ]] && ASIMOV_EXPANDED_DIRS+=("$path")
+        done < <(expand_fixed_dir "$pattern")
+    done
+}
 
 # Record an excluded path: log for counting, compute size only with --stats.
 record_excluded_path() {
@@ -751,14 +860,16 @@ exclude_paths_from_stdin() {
     fi
     verbose_timing "Filtered: ${#to_exclude[@]} new, ${already_excluded} already excluded"
 
-    # Layer 2: Filter descendants of ASIMOV_FIXED_DIRS — they'll be excluded
+    # Layer 2: Filter descendants of the resolved fixed dirs — they'll be excluded
     # unconditionally later, so calling tmutil on them individually is wasted (~11s each).
-    if [[ "$ASIMOV_CONFIG_FIXED_DIRS_ENABLED" == "true" && ${#to_exclude[@]} -gt 0 ]]; then
+    # This must use the *expanded* list: a prefix compare against an unexpanded
+    # glob pattern would never match.
+    if [[ ${#ASIMOV_ALL_FIXED_DIRS[@]} -gt 0 && ${#to_exclude[@]} -gt 0 ]]; then
         local -a filtered_exclude=()
         for path in "${to_exclude[@]}"; do
             local under_fixed=false
             local fixed_dir
-            for fixed_dir in "${ASIMOV_FIXED_DIRS[@]}"; do
+            for fixed_dir in "${ASIMOV_ALL_FIXED_DIRS[@]}"; do
                 if [[ "$path" == "${fixed_dir}/"* ]]; then
                     under_fixed=true
                     break
@@ -975,6 +1086,96 @@ if [[ ! -d "$ASIMOV_ROOT" ]]; then
     exit 1
 fi
 
+# Decide whether application caches are excluded by default.
+#
+# New installs get them; anyone who already ran an earlier Asimov keeps the old
+# behaviour, so an upgrade never silently changes what gets excluded. The verdict
+# is written to ASIMOV_PROFILE_STATE on first run and honoured from then on, so
+# clearing the cache later can't flip it.
+#
+# Caveat: someone who only ever runs `asimov --no-cache` leaves no state at all
+# and is therefore indistinguishable from a new install.
+resolve_app_caches_default() {
+    if [[ -f "$ASIMOV_PROFILE_STATE" ]]; then
+        if grep -qx 'app_caches_default=false' "$ASIMOV_PROFILE_STATE" 2>/dev/null; then
+            echo false
+        else
+            echo true
+        fi
+        return 0
+    fi
+
+    if [[ "$ASIMOV_HAD_PRIOR_STATE" == true ]]; then
+        echo false
+    else
+        echo true
+    fi
+}
+
+# Persist the default so it survives a cache wipe. Skipped when the run is meant
+# to leave no trace (--dry-run, --no-write-cache).
+record_app_caches_default() {
+    local value="$1"
+    [[ -n "$ASIMOV_DRY_RUN" || -n "$ASIMOV_NO_WRITE_CACHE" ]] && return 0
+    [[ -f "$ASIMOV_PROFILE_STATE" ]] && return 0
+
+    local state_dir="${ASIMOV_PROFILE_STATE%/*}"
+    mkdir -p "$state_dir" 2>/dev/null || return 0
+    printf 'app_caches_default=%s\n' "$value" > "$ASIMOV_PROFILE_STATE" 2>/dev/null || return 0
+
+    # Match ensure_cache_dir: when running as root, leave the file owned by the
+    # console user so their next unprivileged run can still read it.
+    if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+        local console_user
+        console_user="$(stat -f '%Su' /dev/console 2>/dev/null || echo '')"
+        if [[ -n "$console_user" && "$console_user" != "root" ]]; then
+            chown -R "$console_user" "$state_dir" 2>/dev/null || true
+        fi
+    fi
+}
+
+app_caches_default="$(resolve_app_caches_default)"
+record_app_caches_default "$app_caches_default"
+
+# An explicit [app_caches] enabled always wins over the install profile.
+if [[ -n "$ASIMOV_CONFIG_APP_CACHES_ENABLED" ]]; then
+    ASIMOV_APP_CACHES_ENABLED="$ASIMOV_CONFIG_APP_CACHES_ENABLED"
+else
+    ASIMOV_APP_CACHES_ENABLED="$app_caches_default"
+fi
+readonly ASIMOV_APP_CACHES_ENABLED
+verbose_timing "App caches enabled: ${ASIMOV_APP_CACHES_ENABLED} (default ${app_caches_default})"
+
+# Expand every fixed-dir pattern up front. Done before find, because
+# exclude_paths_from_stdin's layer-2 filter compares candidate paths against these
+# and needs real directories rather than patterns.
+ASIMOV_EXPANDED_DIRS=()
+ASIMOV_BUILTIN_FIXED_DIRS=()
+ASIMOV_RESOLVED_APP_CACHE_DIRS=()
+ASIMOV_RESOLVED_EXTRA_DIRS=()
+
+if [[ "$ASIMOV_CONFIG_FIXED_DIRS_ENABLED" == "true" ]]; then
+    expand_fixed_dirs "${ASIMOV_FIXED_DIRS[@]}"
+    ASIMOV_BUILTIN_FIXED_DIRS=(${ASIMOV_EXPANDED_DIRS[@]+"${ASIMOV_EXPANDED_DIRS[@]}"})
+fi
+if [[ "$ASIMOV_APP_CACHES_ENABLED" == "true" ]]; then
+    expand_fixed_dirs "${ASIMOV_APP_CACHE_DIRS[@]}"
+    ASIMOV_RESOLVED_APP_CACHE_DIRS=(${ASIMOV_EXPANDED_DIRS[@]+"${ASIMOV_EXPANDED_DIRS[@]}"})
+fi
+if [[ ${#ASIMOV_CONFIG_EXTRA_FIXED_DIRS[@]} -gt 0 ]]; then
+    expand_fixed_dirs "${ASIMOV_CONFIG_EXTRA_FIXED_DIRS[@]}"
+    ASIMOV_RESOLVED_EXTRA_DIRS=(${ASIMOV_EXPANDED_DIRS[@]+"${ASIMOV_EXPANDED_DIRS[@]}"})
+fi
+
+# Combined view used by the layer-2 descendant filter.
+ASIMOV_ALL_FIXED_DIRS=(
+    ${ASIMOV_BUILTIN_FIXED_DIRS[@]+"${ASIMOV_BUILTIN_FIXED_DIRS[@]}"}
+    ${ASIMOV_RESOLVED_APP_CACHE_DIRS[@]+"${ASIMOV_RESOLVED_APP_CACHE_DIRS[@]}"}
+    ${ASIMOV_RESOLVED_EXTRA_DIRS[@]+"${ASIMOV_RESOLVED_EXTRA_DIRS[@]}"}
+)
+readonly -a ASIMOV_ALL_FIXED_DIRS
+verbose_timing "Fixed dirs resolved: ${#ASIMOV_ALL_FIXED_DIRS[@]} directories"
+
 # Determine whether to use the cache or do a full scan.
 # Cache is read when the cache file exists and reads aren't disabled
 # (--no-read-cache / --full-scan / --no-cache force a full scan).
@@ -1051,25 +1252,24 @@ else
 fi
 
 # Exclude built-in fixed dirs only when enabled via config.
-if [[ "$ASIMOV_CONFIG_FIXED_DIRS_ENABLED" == "true" ]]; then
+if [[ ${#ASIMOV_BUILTIN_FIXED_DIRS[@]} -gt 0 ]]; then
     [[ -z "$ASIMOV_QUIET" ]] && printf '\n%s💾 Excluding known cache directories…%s\n' \
         "$ASIMOV_COLOR_INFO" "$ASIMOV_COLOR_RESET"
-    for fixed_dir in "${ASIMOV_FIXED_DIRS[@]}"; do
-        if [[ -d "$fixed_dir" ]]; then
-            echo "$fixed_dir"
-        fi
-    done | exclude_paths_from_stdin
+    printf '%s\n' "${ASIMOV_BUILTIN_FIXED_DIRS[@]}" | exclude_paths_from_stdin
+fi
+
+# Exclude non-developer application caches (default on for new installs).
+if [[ ${#ASIMOV_RESOLVED_APP_CACHE_DIRS[@]} -gt 0 ]]; then
+    [[ -z "$ASIMOV_QUIET" ]] && printf '\n%s🧹 Excluding application caches…%s\n' \
+        "$ASIMOV_COLOR_INFO" "$ASIMOV_COLOR_RESET"
+    printf '%s\n' "${ASIMOV_RESOLVED_APP_CACHE_DIRS[@]}" | exclude_paths_from_stdin
 fi
 
 # Always process extra fixed dirs from config (user explicitly wants them).
-if [[ ${#ASIMOV_CONFIG_EXTRA_FIXED_DIRS[@]} -gt 0 ]]; then
+if [[ ${#ASIMOV_RESOLVED_EXTRA_DIRS[@]} -gt 0 ]]; then
     [[ -z "$ASIMOV_QUIET" ]] && printf '\n%s⚙️  Excluding user-configured directories…%s\n' \
         "$ASIMOV_COLOR_INFO" "$ASIMOV_COLOR_RESET"
-    for fixed_dir in "${ASIMOV_CONFIG_EXTRA_FIXED_DIRS[@]}"; do
-        if [[ -d "$fixed_dir" ]]; then
-            echo "$fixed_dir"
-        fi
-    done | exclude_paths_from_stdin
+    printf '%s\n' "${ASIMOV_RESOLVED_EXTRA_DIRS[@]}" | exclude_paths_from_stdin
 fi
 
 verbose_timing "All exclusions processed"

--- a/asimov
+++ b/asimov
@@ -781,15 +781,23 @@ expand_fixed_dir() {
     shopt -q nullglob && nullglob_was_set=true
     shopt -s nullglob
 
+    # Clear IFS for the expansion only, then put it back immediately. bash 3.2 is
+    # still the system bash on macOS, and it mangles an unquoted array expansion
+    # while IFS is empty: every element gets joined into one string. Restoring IFS
+    # before the array is read back keeps 3.2 and 5.x in agreement.
     local -a matches=()
-    local IFS=''
+    local saved_ifs="$IFS"
+    IFS=''
     # shellcheck disable=SC2206  # deliberate: globbing with splitting disabled
     matches=($pattern)
+    IFS="$saved_ifs"
 
     [[ "$nullglob_was_set" == false ]] && shopt -u nullglob
 
+    [[ ${#matches[@]} -eq 0 ]] && return 0
+
     local match
-    for match in ${matches[@]+"${matches[@]}"}; do
+    for match in "${matches[@]}"; do
         [[ -d "$match" ]] && printf '%s\n' "$match"
     done
     return 0

--- a/tests/behavior.bats
+++ b/tests/behavior.bats
@@ -946,3 +946,24 @@ enabled = false"
   refute_excluded "${HOME}/Library/Application Support/Asana/Service Worker/CacheStorage"
   refute_excluded "${HOME}/Library/Application Support/Claude/vm_bundles"
 }
+
+@test "fixed dirs: glob expansion works under bash 3.2 (the system bash)" {
+  # asimov ships with #!/usr/bin/env bash, so on a stock Mac it runs under bash
+  # 3.2. bash 3.2 joins the elements of an unquoted array expansion while IFS is
+  # empty, which silently reduced every multi-match glob to nothing. The local
+  # suite runs under whatever bash is first on PATH, so this asserts 3.2 directly.
+  [[ -x /bin/bash ]] || skip "no /bin/bash available"
+  mkdir -p "${HOME}/builds/alpha/dist" "${HOME}/builds/beta/dist" "${HOME}/app/Code Cache"
+
+  run /bin/bash -c '
+    set -Eeu -o pipefail
+    eval "$(awk "/^expand_fixed_dir\(\)/,/^}/" "$1")"
+    expand_fixed_dir "$2/builds/*/dist"
+    expand_fixed_dir "$2/*/Code Cache"
+  ' _ "${BATS_TEST_DIRNAME}/../asimov" "$HOME"
+
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"${HOME}/builds/alpha/dist"* ]]
+  [[ "$output" == *"${HOME}/builds/beta/dist"* ]]
+  [[ "$output" == *"${HOME}/app/Code Cache"* ]]
+}

--- a/tests/behavior.bats
+++ b/tests/behavior.bats
@@ -898,3 +898,51 @@ enabled = false"
   run_asimov --full-scan
   refute_excluded "${HOME}/Library/Application Support/Spotify/PersistentCache"
 }
+
+# =============================================================================
+# Application caches: service-worker caches
+# =============================================================================
+
+@test "app caches: excludes the service-worker CacheStorage" {
+  create_app_support_dir "Asana/Service Worker/CacheStorage"
+  create_app_support_dir "Google/Chrome/Default/Service Worker/CacheStorage"
+  create_app_support_dir "Arc/User Data/Profile 3/Service Worker/CacheStorage"
+  run_asimov
+  assert_excluded "${HOME}/Library/Application Support/Asana/Service Worker/CacheStorage"
+  assert_excluded "${HOME}/Library/Application Support/Google/Chrome/Default/Service Worker/CacheStorage"
+  assert_excluded "${HOME}/Library/Application Support/Arc/User Data/Profile 3/Service Worker/CacheStorage"
+}
+
+@test "app caches: excludes the service-worker ScriptCache" {
+  create_app_support_dir "Asana/Service Worker/ScriptCache"
+  create_app_support_dir "Google/Chrome/Default/Service Worker/ScriptCache"
+  run_asimov
+  assert_excluded "${HOME}/Library/Application Support/Asana/Service Worker/ScriptCache"
+  assert_excluded "${HOME}/Library/Application Support/Google/Chrome/Default/Service Worker/ScriptCache"
+}
+
+@test "app caches: leaves the service-worker registration database alone" {
+  # Database/ holds the registrations. Losing it logs you out of web apps and
+  # drops their offline mode, so only the cache siblings are excluded.
+  create_app_support_dir "Asana/Service Worker/CacheStorage"
+  create_app_support_dir "Asana/Service Worker/Database"
+  run_asimov
+  refute_excluded "${HOME}/Library/Application Support/Asana/Service Worker"
+  refute_excluded "${HOME}/Library/Application Support/Asana/Service Worker/Database"
+}
+
+@test "app caches: excludes Claude Desktop's sandbox images" {
+  create_app_support_dir "Claude/vm_bundles"
+  run_asimov
+  assert_excluded "${HOME}/Library/Application Support/Claude/vm_bundles"
+}
+
+@test "app caches: service-worker caches respect the opt-out" {
+  create_app_support_dir "Asana/Service Worker/CacheStorage"
+  create_app_support_dir "Claude/vm_bundles"
+  write_config "[app_caches]
+enabled = false"
+  run_asimov
+  refute_excluded "${HOME}/Library/Application Support/Asana/Service Worker/CacheStorage"
+  refute_excluded "${HOME}/Library/Application Support/Claude/vm_bundles"
+}

--- a/tests/behavior.bats
+++ b/tests/behavior.bats
@@ -734,3 +734,167 @@ extra = ${HOME}/Code"
   [[ "$(count_exclusions)" -eq 1 ]]
   refute_excluded "${HOME}/Projects/app/node_modules"
 }
+
+# =============================================================================
+# Glob support in fixed directories
+# =============================================================================
+
+@test "fixed dirs: extra path expands a glob" {
+  mkdir -p "${HOME}/builds/alpha/dist"
+  mkdir -p "${HOME}/builds/beta/dist"
+  write_config "[fixed_dirs]
+extra = ~/builds/*/dist"
+
+  run_asimov
+
+  assert_excluded "${HOME}/builds/alpha/dist"
+  assert_excluded "${HOME}/builds/beta/dist"
+}
+
+@test "fixed dirs: glob expansion keeps paths containing spaces intact" {
+  mkdir -p "${HOME}/Application Support/My App/Code Cache"
+  write_config "[fixed_dirs]
+extra = ~/Application Support/*/Code Cache"
+
+  run_asimov
+
+  assert_excluded "${HOME}/Application Support/My App/Code Cache"
+}
+
+@test "fixed dirs: glob matching nothing is not an error" {
+  write_config "[fixed_dirs]
+extra = ~/nowhere/*/dist"
+
+  run_asimov
+
+  [[ "$status" -eq 0 ]]
+  [[ "$(count_exclusions)" -eq 0 ]]
+}
+
+@test "fixed dirs: glob only matches directories, not files" {
+  mkdir -p "${HOME}/builds/alpha"
+  touch "${HOME}/builds/alpha/dist"
+  write_config "[fixed_dirs]
+extra = ~/builds/*/dist"
+
+  run_asimov
+
+  [[ "$status" -eq 0 ]]
+  refute_excluded "${HOME}/builds/alpha/dist"
+}
+
+# =============================================================================
+# Application caches
+# =============================================================================
+
+# Create a directory under ~/Library/Application Support.
+create_app_support_dir() {
+  mkdir -p "${HOME}/Library/Application Support/$1"
+}
+
+# Simulate a machine that has already run an earlier version of Asimov.
+simulate_prior_install() {
+  mkdir -p "${HOME}/.cache/asimov"
+  echo "${HOME}/some/old/path" > "${HOME}/.cache/asimov/excluded"
+}
+
+@test "app caches: excluded by default on a new install" {
+  create_app_support_dir "Spotify/PersistentCache"
+  run_asimov
+  assert_excluded "${HOME}/Library/Application Support/Spotify/PersistentCache"
+}
+
+@test "app caches: matches a named cache one level below Application Support" {
+  create_app_support_dir "discord/Cache"
+  create_app_support_dir "Code/CachedExtensionVSIXs"
+  run_asimov
+  assert_excluded "${HOME}/Library/Application Support/discord/Cache"
+  assert_excluded "${HOME}/Library/Application Support/Code/CachedExtensionVSIXs"
+}
+
+@test "app caches: matches a named cache two levels below Application Support" {
+  create_app_support_dir "Arc/User Data/Code Cache"
+  create_app_support_dir "Google/Chrome/component_crx_cache"
+  run_asimov
+  assert_excluded "${HOME}/Library/Application Support/Arc/User Data/Code Cache"
+  assert_excluded "${HOME}/Library/Application Support/Google/Chrome/component_crx_cache"
+}
+
+@test "app caches: leaves non-cache directories alone" {
+  create_app_support_dir "Code/User"
+  create_app_support_dir "Google/Chrome/Default"
+  run_asimov
+  refute_excluded "${HOME}/Library/Application Support/Code/User"
+  refute_excluded "${HOME}/Library/Application Support/Google/Chrome/Default"
+}
+
+@test "app caches: not excluded when the machine has prior Asimov state" {
+  simulate_prior_install
+  create_app_support_dir "Spotify/PersistentCache"
+  run_asimov
+  refute_excluded "${HOME}/Library/Application Support/Spotify/PersistentCache"
+}
+
+@test "app caches: existing user can opt in explicitly" {
+  simulate_prior_install
+  create_app_support_dir "Spotify/PersistentCache"
+  write_config "[app_caches]
+enabled = true"
+  run_asimov
+  assert_excluded "${HOME}/Library/Application Support/Spotify/PersistentCache"
+}
+
+@test "app caches: new install can opt out explicitly" {
+  create_app_support_dir "Spotify/PersistentCache"
+  write_config "[app_caches]
+enabled = false"
+  run_asimov
+  refute_excluded "${HOME}/Library/Application Support/Spotify/PersistentCache"
+}
+
+@test "app caches: first run records the resolved default" {
+  run_asimov
+  [[ -f "${HOME}/.local/state/asimov/profile" ]]
+  grep -qx 'app_caches_default=true' "${HOME}/.local/state/asimov/profile"
+}
+
+@test "app caches: an upgrader's recorded default is off" {
+  simulate_prior_install
+  run_asimov
+  grep -qx 'app_caches_default=false' "${HOME}/.local/state/asimov/profile"
+}
+
+@test "app caches: recorded default survives a cache wipe" {
+  # Existing user: default resolves to off and is recorded.
+  simulate_prior_install
+  run_asimov
+  grep -qx 'app_caches_default=false' "${HOME}/.local/state/asimov/profile"
+
+  # Wiping the cache would otherwise make them look like a new install.
+  rm -rf "${HOME}/.cache/asimov"
+  create_app_support_dir "Spotify/PersistentCache"
+  run_asimov
+
+  refute_excluded "${HOME}/Library/Application Support/Spotify/PersistentCache"
+}
+
+@test "app caches: dry-run does not record a default" {
+  run_asimov --dry-run
+  [[ "$status" -eq 0 ]]
+  [[ ! -f "${HOME}/.local/state/asimov/profile" ]]
+}
+
+@test "app caches: --no-write-cache does not record a default" {
+  run_asimov --no-write-cache
+  [[ "$status" -eq 0 ]]
+  [[ ! -f "${HOME}/.local/state/asimov/profile" ]]
+}
+
+@test "app caches: a full scan by an existing user still counts as an upgrade" {
+  # --no-read-cache clears the state files, so the prior-install signal must be
+  # captured before that happens.
+  simulate_prior_install
+  create_app_support_dir "Spotify/PersistentCache"
+  run_asimov --full-scan
+  refute_excluded "${HOME}/Library/Application Support/Spotify/PersistentCache"
+}


### PR DESCRIPTION
Follow-up to #109, and **mergeable without it** (both branches carry the same base commit, so whichever lands second drops it on rebase).

Adds the two largest remaining candidates from the #39 survey: **12.6 GB across 32 directories** on one everyday Mac.

## Feedback wanted

These were the two entries I was least comfortable auto-approving, which is why they are split out rather than folded into #109. Merge that one for the safe set; merge this one only if the argument below holds up.

1. **Is `Service Worker/CacheStorage` genuinely safe to drop?** My reasoning is below. If you have a case where losing it broke an installed PWA or an offline-capable app, that kills this PR.
2. **Is splitting `Service Worker/` the right call**, or is it too clever? The alternative is excluding the whole directory, which is simpler but risks the registrations.
3. **Is `Claude/vm_bundles` too vendor-specific** for a built-in?

## Service worker caches

Excluded:

- `Service Worker/CacheStorage` (6.98 GB here). This is an HTTP cache **by specification**. Browsers already evict it under storage pressure without asking, and every entry refetches from origin. If losing it broke an app, that app would already be broken by a routine eviction.
- `Service Worker/ScriptCache` (132 MB). Cached copies of the worker scripts themselves, likewise refetched.

Deliberately **not** excluded:

- `Service Worker/Database`. This holds the worker registrations. Losing it is what logs you out of a web app or drops its offline mode. It is also tiny, so there is nothing to gain.

That split is the whole point of this PR. Excluding the `Service Worker` parent would be simpler and would take the registrations with it.

Listed at three depths, to cover both single-profile Electron apps (`Asana/Service Worker`) and multi-profile browsers (`Arc/User Data/Profile 3/Service Worker`).

## Claude vm_bundles

5.76 GB of sandbox images, rebuilt on demand. Large, purely derived, and no user data in it. Included because the size is hard to ignore, but it is the most vendor-specific entry in either PR and I will drop it without complaint.

## What stays rejected

For the record, the rest of the "maybe" list from #39 stays out, and I do not think any of it is close:

| Candidate | Size here | Why not |
|---|---|---|
| `Group Containers` | 4.63 GB | WhatsApp and Office message stores |
| `User/globalStorage` | 2.96 GB | AI chat history, extension state |
| Firefox/Thunderbird `*/storage` | 2.72 GB | Per-site data, offline mail |
| `User/workspaceStorage` | 1.04 GB | Real per-workspace state |
| `IndexedDB` | 993 MB | Local-first app data: drafts, offline documents |
| `WebStorage` (parent) | 535 MB | localStorage. Only its `CacheStorage` child is taken, in #109 |
| `User/History` | 132 MB | Local file history, an undo safety net |
| `HTTPStorages` | 167 MB | Cookies and credentials |
| `Local`/`Session Storage` | 88 MB | Session state, and too small to be worth any risk |
| `MobileSync/Backup` | n/a | iOS device backups. Arguably the most backup-worthy thing on a Mac |

## Tests

5 new Bats tests: `CacheStorage` and `ScriptCache` at each depth, `vm_bundles`, the opt-out, and an explicit assertion that `Service Worker/Database` and the `Service Worker` parent are left alone.

`make check` passes: 195 tests, shellcheck clean, CI green on macos-14 and macos-15. Includes the bash 3.2 glob-expansion fix described in #109 (both branches carry it, so each is green standalone).
