### PR TITLE
ci: test across both macOS bash versions in a parallel matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,19 +5,69 @@ on:
     branches: [main]
   pull_request:
 
+# A newer push to the same ref supersedes an in-flight run.
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  # Shellcheck is interpreter-independent, so it runs once rather than once per
+  # matrix cell, in parallel with the test jobs.
+  lint:
+    name: shellcheck
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install shellcheck
+        run: brew list shellcheck >/dev/null 2>&1 || brew install shellcheck
+
+      - name: Run shellcheck
+        run: make lint
+
+  # asimov ships with #!/usr/bin/env bash, so the bash it runs under is whatever
+  # the user happens to have first on PATH. On macOS that is one of exactly two
+  # things: the system bash at /bin/bash, still 3.2 because Apple froze it at the
+  # last GPLv2 release, or a modern 5.x from Homebrew. The two disagree on array
+  # and IFS semantics, so both are tested.
+  #
+  # Every cell runs concurrently, and fail-fast is off so one failing combination
+  # cannot hide the others.
   test:
+    name: ${{ matrix.os }} / bash ${{ matrix.bash }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [macos-14, macos-15]
+        bash: [system, homebrew]
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install dependencies
-        run: brew install bats-core shellcheck
+      - name: Install test dependencies
+        run: |
+          brew list bats-core >/dev/null 2>&1 || brew install bats-core
+          brew list parallel  >/dev/null 2>&1 || brew install parallel
+          if [ "${{ matrix.bash }}" = "homebrew" ]; then
+            brew list bash >/dev/null 2>&1 || brew install bash
+          fi
+          # Stop GNU parallel asking to be cited, which it does on stderr on
+          # first use and which has no non-interactive answer.
+          mkdir -p "${HOME}/.parallel" && touch "${HOME}/.parallel/will-cite"
 
-      - name: Run tests and linting
-        run: make check
+      - name: Select bash
+        id: select
+        run: |
+          if [ "${{ matrix.bash }}" = "system" ]; then
+            bin=/bin/bash
+          else
+            bin="$(brew --prefix)/bin/bash"
+          fi
+          echo "bin=${bin}" >> "$GITHUB_OUTPUT"
+          "$bin" --version | head -1
+
+      # BATS_JOBS runs the suite concurrently. Each test gets its own temp HOME in
+      # setup(), so there is no shared state between them.
+      - name: Run tests
+        run: make test BASH_BIN='${{ steps.select.outputs.bin }}' BATS_JOBS=4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,17 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- `make test-system-bash` runs the suite under the macOS system bash (3.2), which is what
+  most users get — `asimov` starts with `#!/usr/bin/env bash`, and a development machine
+  usually has 5.x first on `PATH`. `make test BASH_BIN=<path>` pins any interpreter, and
+  `make test BATS_JOBS=N` runs tests concurrently (needs GNU parallel).
+
 ### Changed
+
+- CI now runs a matrix of both macOS versions × both bash versions (system 3.2 and Homebrew
+  5.x), with ShellCheck split into its own job so it runs once instead of once per cell.
+  All jobs run in parallel, `fail-fast` is off so one failing combination cannot hide the
+  others, and a newer push cancels an in-flight run for the same ref.
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,12 +24,35 @@ make check
 |---|---|
 | `make help` | List available make targets with descriptions |
 | `make test` | Run the [Bats](https://github.com/bats-core/bats-core) test suite |
+| `make test-system-bash` | Run the suite under the macOS system bash (3.2) |
 | `make lint` | Run [ShellCheck](https://www.shellcheck.net/) on all shell scripts |
 | `make check` | Run both tests and linting |
 | `make version` | Print asimov version |
 | `make exclusions` | List all paths excluded from Time Machine (requires sudo) |
 
 To run a single test by name: `bats tests/behavior.bats --filter "substring of test name"` or `bats tests/sentinels.bats --filter "npm"`.
+
+### Which bash your tests run under
+
+`asimov` starts with `#!/usr/bin/env bash`, so it runs under whichever `bash` comes first on `PATH`. On macOS that is one of two very different things:
+
+- `/bin/bash`, the system bash, still **3.2** because Apple froze it at the last GPLv2 release. This is what most users get.
+- A **5.x** build from Homebrew, which is probably what *you* get.
+
+They disagree on array and IFS semantics, so a change can pass locally and fail for users. Before opening a PR touching shell logic, run:
+
+```sh
+make test-system-bash        # or: make test BASH_BIN=/bin/bash
+```
+
+CI runs the full matrix (both macOS versions × both bash versions) on every PR, so it will catch this either way, but the local target is faster than a round trip.
+
+Tests can also run concurrently, which needs GNU parallel:
+
+```sh
+brew install parallel
+make test BATS_JOBS=4
+```
 
 The main script supports `--help`, `--version`, `--dry-run`, `--verbose`, and `--quiet`; unknown options exit with an error.
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help test lint check bench bench-home install uninstall exclusions version prep-release release release-beta verify-release
+.PHONY: help test test-system-bash lint check bench bench-home install uninstall exclusions version prep-release release release-beta verify-release
 
 # Which GitHub repo + git remote releases target. Defaults to the project's home
 # (AsimovMac/asimov). Pinning GH_REPO to $(REPO) stops another configured remote
@@ -23,11 +23,22 @@ exclusions: ## List all paths excluded from Time Machine
 ## —————————— 🛠 Development ———————————————————————————————————
 
 
-test: ## Run Bats tests
-	@bats tests/sentinels.bats tests/behavior.bats tests/cache.bats tests/format.bats tests/plist.bats
+# Pin the bash that runs asimov itself. Its shebang is #!/usr/bin/env bash, so
+# by default it runs under whichever bash is first on PATH — usually 5.x locally
+# and 3.2 for anyone on a stock Mac. Use `make test BASH_BIN=/bin/bash` to check
+# what your users actually get; CI runs the matrix for you.
+BASH_BIN ?=
+# Run tests concurrently (requires GNU parallel: brew install parallel).
+BATS_JOBS ?=
+
+test: ## Run Bats tests (BASH_BIN=/bin/bash pins the interpreter; BATS_JOBS=N runs in parallel)
+	@BASH_BIN="$(BASH_BIN)" BATS_JOBS="$(BATS_JOBS)" scripts/test.sh
+
+test-system-bash: ## Run Bats tests under the macOS system bash (3.2), as shipped users get
+	@$(MAKE) --no-print-directory test BASH_BIN=/bin/bash
 
 lint: ## Run Shellcheck on all shell scripts
-	@shellcheck asimov scripts/install.sh scripts/install-remote.sh scripts/uninstall.sh scripts/prep-release.sh tests/test_helper.bash tests/bin/run-tests.sh tests/bin/tmutil tests/bin/mdfind
+	@shellcheck asimov scripts/install.sh scripts/install-remote.sh scripts/uninstall.sh scripts/prep-release.sh scripts/test.sh tests/test_helper.bash tests/bin/run-tests.sh tests/bin/tmutil tests/bin/mdfind
 
 check: test lint ## Run tests and linting
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Run the Bats suite.
+#
+# Environment:
+#   BASH_BIN   pin the bash that runs asimov itself (default: first bash on PATH)
+#   BATS_JOBS  run this many tests concurrently (requires GNU parallel)
+
+set -Eeu -o pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+readonly TEST_FILES=(
+    tests/sentinels.bats
+    tests/behavior.bats
+    tests/cache.bats
+    tests/format.bats
+    tests/plist.bats
+)
+
+# asimov's shebang is #!/usr/bin/env bash, so in real use its interpreter is
+# whichever bash comes first on PATH: 3.2 on a stock Mac, 5.x on most development
+# machines. They are not equivalent, so the suite has to be runnable under each.
+# The helper reads ASIMOV_TEST_BASH and launches asimov with it explicitly, which
+# leaves Bats itself running under its own bash.
+if [[ -n "${BASH_BIN:-}" ]]; then
+    if [[ ! -x "$BASH_BIN" ]]; then
+        echo "test.sh: not executable: ${BASH_BIN}" >&2
+        exit 1
+    fi
+    ASIMOV_TEST_BASH="$BASH_BIN"
+    export ASIMOV_TEST_BASH
+    printf 'Running asimov under %s\n' "$("$BASH_BIN" --version | head -1)"
+fi
+
+bats_flags=()
+if [[ -n "${BATS_JOBS:-}" ]]; then
+    if command -v parallel >/dev/null 2>&1; then
+        bats_flags+=(--jobs "$BATS_JOBS")
+    else
+        echo "test.sh: BATS_JOBS set but GNU parallel is not installed; running serially" >&2
+    fi
+fi
+
+exec bats ${bats_flags[@]+"${bats_flags[@]}"} "${TEST_FILES[@]}"

--- a/tests/behavior.bats
+++ b/tests/behavior.bats
@@ -153,7 +153,7 @@ load test_helper
 }
 
 @test "exits with error when root directory does not exist" {
-  run env HOME=/nonexistent-asimov-root "${BATS_TEST_DIRNAME}/../asimov"
+  run env HOME=/nonexistent-asimov-root "${ASIMOV_CMD[@]}"
   [[ "$status" -eq 1 ]]
   [[ "$output" == *"root directory"* ]]
   [[ "$output" == *"does not exist"* ]]

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -11,6 +11,17 @@ setup() {
   ASIMOV_TEST_EXCLUSIONS="${TEST_TEMP_DIR}/.exclusions"
   export ASIMOV_TEST_EXCLUSIONS
   touch "$ASIMOV_TEST_EXCLUSIONS"
+
+  # How to launch the script under test. asimov's shebang is #!/usr/bin/env bash,
+  # so in real use it runs under whichever bash comes first on PATH: 3.2 on a
+  # stock Mac, 5.x on most development machines. ASIMOV_TEST_BASH pins that
+  # interpreter so CI can run the whole suite under each, and Bats keeps running
+  # under its own bash either way.
+  if [[ -n "${ASIMOV_TEST_BASH:-}" ]]; then
+    ASIMOV_CMD=("$ASIMOV_TEST_BASH" "${BATS_TEST_DIRNAME}/../asimov")
+  else
+    ASIMOV_CMD=("${BATS_TEST_DIRNAME}/../asimov")
+  fi
 }
 
 # Clean up the temporary directory after each test.
@@ -34,7 +45,7 @@ create_project() {
 
 # Run the asimov script under test. Pass any arguments (e.g. --dry-run, --help).
 run_asimov() {
-  run "${BATS_TEST_DIRNAME}/../asimov" "$@"
+  run "${ASIMOV_CMD[@]}" "$@"
 }
 
 # Return the number of exclusions recorded by the mock tmutil.


### PR DESCRIPTION
`asimov` starts with `#!/usr/bin/env bash`, so it runs under whichever `bash` comes first on `PATH`. On macOS that is one of two very different things:

- `/bin/bash`, the **system bash**, still **3.2** because Apple froze it at the last GPLv2 release. This is what most users get.
- A **5.x** build from Homebrew, which is what a development machine usually has.

They disagree on array and IFS semantics. Until now a change could pass `make check` locally **and** pass CI, and still be broken for the majority of users, because both were running 5.x.

This is not hypothetical. It is exactly how the glob expansion in #109 shipped broken: bash 3.2 joins the elements of an unquoted array expansion while `IFS` is empty, so any glob with more than one match silently expanded to nothing. Single-match globs worked, so it looked fine locally.

## What changes

**Matrix**: `os` × `bash` = 4 cells, all concurrent, `fail-fast: false` so one failing combination cannot hide the others.

| | macos-14 | macos-15 |
|---|---|---|
| system bash 3.2 | ✅ | ✅ |
| Homebrew bash 5.x | ✅ | ✅ |

**ShellCheck moves into its own job.** It is interpreter-independent, so it now runs once alongside the test cells instead of four times over.

**Concurrency group** cancels an in-flight run when the same ref is pushed again.

**`BATS_JOBS`** runs the suite concurrently within each cell (GNU parallel). Each test already creates its own temp `HOME` in `setup()`, so there is no shared state between them.

## Locally

```sh
make test-system-bash            # the suite under bash 3.2
make test BASH_BIN=/opt/homebrew/bin/bash   # or any interpreter
make test BATS_JOBS=4            # concurrent (brew install parallel)
```

## Implementation note

`scripts/test.sh` sets `ASIMOV_TEST_BASH`, and the Bats helper launches `asimov` with that interpreter explicitly. The obvious alternative was a `PATH` shim, but that drags **Bats itself** down to 3.2 along with the script under test, which is both slower and not what is being tested. This way Bats keeps running under its own bash.

## Why only two bash versions

Those are the only two that exist on macOS in practice. Apple ships 3.2 and Homebrew ships 5.x; there is no supported route to a 4.x build short of compiling from source, and effectively nobody runs `asimov` under one. The `bash` axis is a plain matrix list, so adding a version later is a one-line change.

## Check names

The required-check names change from `test (macos-14)` / `test (macos-15)` to:

- `shellcheck`
- `macos-14 / bash system`
- `macos-14 / bash homebrew`
- `macos-15 / bash system`
- `macos-15 / bash homebrew`

`main` currently has **no branch protection or rulesets configured**, so nothing breaks on merge. If you add protection later, use the names above.
