### PR TITLE
feat: warn and confirm before running as root, and unify error styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   5.x), with ShellCheck split into its own job so it runs once instead of once per cell.
   All jobs run in parallel, `fail-fast` is off so one failing combination cannot hide the
   others, and a newer push cancels an in-flight run for the same ref.
+- Errors and warnings are now styled consistently: red `✗` for errors, yellow `⚠` for warnings, with dim indented hint lines. Colors on stderr are enabled based on stderr's own terminal check, so a redirected stdout no longer strips (or leaks) codes on diagnostics
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   most users get — `asimov` starts with `#!/usr/bin/env bash`, and a development machine
   usually has 5.x first on `PATH`. `make test BASH_BIN=<path>` pins any interpreter, and
   `make test BATS_JOBS=N` runs tests concurrently (needs GNU parallel).
+- Guard against running under `sudo`. A root run now prints a warning explaining why it is unnecessary (Time Machine stores exclusions as an xattr on each directory) and harmful (it leaves `~/.cache/asimov` root-owned), points to the better alternatives, and asks for confirmation before continuing. Declining exits without changing anything; non-interactive runs (launchd, CI) warn and continue. Set `ASIMOV_ALLOW_ROOT=1` to skip the check entirely
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,9 +90,29 @@ type(scope): short description
 - `test: add coverage for Go modules`
 - `docs: update installation instructions`
 
+## Worktrees
+
+Work on a **git worktree**, not on a checked-out `main`. Each worktree is its own directory with its own branch, so a long-running change never blocks a quick fix, and `main` stays clean for releases.
+
+```sh
+git worktree add ../asimov-<topic> -b <type>/<topic>   # new branch in a sibling directory
+cd ../asimov-<topic>
+make check
+```
+
+When the PR is merged, remove it:
+
+```sh
+git worktree remove ../asimov-<topic>
+git worktree prune
+git branch -d <type>/<topic>
+```
+
+`git worktree list` shows what you have open. Note that each worktree gets a fresh, untracked state — install test dependencies once (they're global via Homebrew) and re-run `make check` inside the worktree.
+
 ## Pull requests
 
-- Branch from `main` (the default branch).
+- Branch from `main` (the default branch) — see [Worktrees](#worktrees) above.
 - Keep PRs focused — one feature or fix per PR.
 - Ensure `make check` passes before submitting.
 - Update `CHANGELOG.md` for user-facing changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,7 @@ tests/
   sentinels.bats        # Tests for each dependency pattern
   behavior.bats         # Tests for edge cases and general behavior
   format.bats           # Unit tests for format_size_kb()
+  root_guard.bats       # Tests for the sudo/root guard and styled diagnostics
   plist.bats            # Tests for the LaunchAgent plist
   test_helper.bash      # Shared setup/teardown and assertions
   bin/tmutil            # Mock tmutil for testing

--- a/README.md
+++ b/README.md
@@ -125,6 +125,17 @@ Asimov keeps a cache under `~/.cache/asimov/` so repeat runs are near-instant. T
 - `--no-write-cache` — *"don't touch state."* Uses the fast cache to read, but persists nothing. Handy with `--dry-run`.
 - Both together = a fully stateless run that reads and writes nothing. **`--no-cache` is an alias for this.**
 
+### Don't run it with `sudo`
+
+Time Machine stores each exclusion as an extended attribute on the directory itself, so root buys you nothing — but it does leave `~/.cache/asimov` owned by root, which breaks your next normal run. Asimov warns and asks for confirmation if it detects a root run; decline and nothing is changed.
+
+```sh
+asimov                                  # run it as yourself
+sudo chown -R "$(whoami)" ~/.cache/asimov   # already ran it with sudo? fix ownership
+```
+
+If you deliberately run Asimov as root from your own automation, set `ASIMOV_ALLOW_ROOT=1` to skip the check.
+
 
 ## Schedule
 

--- a/asimov
+++ b/asimov
@@ -48,11 +48,13 @@ if [[ -t 2 ]]; then
     readonly ASIMOV_ERR_ERROR=$'\033[0;31m'
     readonly ASIMOV_ERR_WARN=$'\033[0;33m'
     readonly ASIMOV_ERR_DIM=$'\033[0;90m'
+    readonly ASIMOV_ERR_BOLD=$'\033[1m'
     readonly ASIMOV_ERR_RESET=$'\033[0m'
 else
     readonly ASIMOV_ERR_ERROR=''
     readonly ASIMOV_ERR_WARN=''
     readonly ASIMOV_ERR_DIM=''
+    readonly ASIMOV_ERR_BOLD=''
     readonly ASIMOV_ERR_RESET=''
 fi
 
@@ -64,6 +66,16 @@ msg_error() {
 # Yellow warning line on stderr. Shown even under --quiet: it is not routine output.
 msg_warn() {
     printf '%s⚠ asimov: %s%s\n' "$ASIMOV_ERR_WARN" "$*" "$ASIMOV_ERR_RESET" >&2
+}
+
+# Dim continuation line on stderr, indented to sit under a warning or error.
+# Called with no arguments (or an empty one) it prints a bare blank line.
+msg_hint() {
+    if [[ -z "$*" ]]; then
+        printf '\n' >&2
+        return
+    fi
+    printf '%s  %s%s\n' "$ASIMOV_ERR_DIM" "$*" "$ASIMOV_ERR_RESET" >&2
 }
 
 print_usage() {
@@ -141,6 +153,70 @@ fi
 # Named constants for size formatting.
 readonly ASIMOV_KB_PER_MB=1024
 readonly ASIMOV_KB_PER_GB=1048576
+
+# --- Root / sudo guard ---
+
+# Effective UID. ASIMOV_TEST_UID is a test seam so the suite can simulate a root run.
+asimov_uid() {
+    if [[ -n "${ASIMOV_TEST_UID:-}" ]]; then
+        printf '%s' "$ASIMOV_TEST_UID"
+    else
+        printf '%s' "${EUID:-$(id -u)}"
+    fi
+}
+
+# True when we can actually ask the user something. ASIMOV_TEST_INTERACTIVE is a
+# test seam (bats runs with pipes on both descriptors).
+asimov_is_interactive() {
+    [[ -n "${ASIMOV_TEST_INTERACTIVE:-}" ]] && return 0
+    [[ -t 0 && -t 2 ]]
+}
+
+# Warn (and, when interactive, ask for confirmation) before running as root.
+#
+# `sudo asimov` looks like the "thorough" way to run this, but it is worse in
+# every direction: tmutil writes the exclusion as an xattr on each directory, so
+# root buys nothing, while the cache and state files under ~/.cache/asimov come
+# out root-owned — and the next normal run can no longer write them.
+#
+# Set ASIMOV_ALLOW_ROOT=1 to skip this entirely (deliberate root automation).
+warn_if_running_as_root() {
+    [[ "$(asimov_uid)" -eq 0 ]] || return 0
+    [[ -n "${ASIMOV_ALLOW_ROOT:-}" ]] && return 0
+
+    msg_warn "you are running asimov as root (sudo). That is almost never what you want."
+    msg_hint ""
+    msg_hint "Time Machine stores each exclusion as an xattr on the directory itself, so"
+    msg_hint "root gains you nothing — but it does leave ~/.cache/asimov owned by root,"
+    msg_hint "which breaks your next normal run."
+    msg_hint ""
+    msg_hint "Do this instead:"
+    msg_hint "    asimov                                                    # run it as yourself"
+    msg_hint "    launchctl kickstart gui/\$(id -u)/com.stevegrunwell.asimov  # or let the agent do it"
+    msg_hint ""
+    msg_hint "Already ran it with sudo? Fix the ownership with:"
+    msg_hint "    sudo chown -R \"\$(whoami)\" ~/.cache/asimov"
+    msg_hint ""
+
+    if ! asimov_is_interactive; then
+        msg_hint "Non-interactive session — continuing anyway."
+        msg_hint "Set ASIMOV_ALLOW_ROOT=1 to silence this warning."
+        return 0
+    fi
+
+    local reply=''
+    printf '%s  Continue as root anyway? [y/N] %s' "$ASIMOV_ERR_BOLD" "$ASIMOV_ERR_RESET" >&2
+    read -r reply || true
+    case "$reply" in
+        [yY] | [yY][eE][sS]) msg_warn "continuing as root." ;;
+        *)
+            msg_error "aborted — nothing was changed."
+            exit 1
+            ;;
+    esac
+}
+
+warn_if_running_as_root
 
 # Print a dim timestamped debug line when --verbose is set.
 # Uses bash's built-in $SECONDS variable (auto-increments from 0 at script start).

--- a/asimov
+++ b/asimov
@@ -29,6 +29,43 @@ trap 'rm -f "$ASIMOV_SIZE_LOG" "$ASIMOV_EXCLUDED_CACHE" "$ASIMOV_PATH_CACHE_TMP"
 # Keep ASIMOV_VERSION in sync with CHANGELOG and package managers (e.g. Homebrew).
 readonly ASIMOV_VERSION='0.10.0'
 
+# --- Message styling ---
+# Progress/summary styling for stdout; disabled when stdout is not a terminal
+# (e.g. launchd, pipes, redirects).
+if [[ -t 1 ]]; then
+    readonly ASIMOV_COLOR_INFO=$'\033[0;36m'
+    readonly ASIMOV_COLOR_SUCCESS=$'\033[0;32m'
+    readonly ASIMOV_COLOR_RESET=$'\033[0m'
+else
+    readonly ASIMOV_COLOR_INFO=''
+    readonly ASIMOV_COLOR_SUCCESS=''
+    readonly ASIMOV_COLOR_RESET=''
+fi
+
+# Diagnostics all go to stderr, which is redirected independently of stdout —
+# so it gets its own colors, gated on its own terminal check.
+if [[ -t 2 ]]; then
+    readonly ASIMOV_ERR_ERROR=$'\033[0;31m'
+    readonly ASIMOV_ERR_WARN=$'\033[0;33m'
+    readonly ASIMOV_ERR_DIM=$'\033[0;90m'
+    readonly ASIMOV_ERR_RESET=$'\033[0m'
+else
+    readonly ASIMOV_ERR_ERROR=''
+    readonly ASIMOV_ERR_WARN=''
+    readonly ASIMOV_ERR_DIM=''
+    readonly ASIMOV_ERR_RESET=''
+fi
+
+# Red error line on stderr. Usage: msg_error "unknown option '--foo'"
+msg_error() {
+    printf '%s✗ asimov: %s%s\n' "$ASIMOV_ERR_ERROR" "$*" "$ASIMOV_ERR_RESET" >&2
+}
+
+# Yellow warning line on stderr. Shown even under --quiet: it is not routine output.
+msg_warn() {
+    printf '%s⚠ asimov: %s%s\n' "$ASIMOV_ERR_WARN" "$*" "$ASIMOV_ERR_RESET" >&2
+}
+
 print_usage() {
     printf 'Usage: asimov [--dry-run] [--verbose] [--quiet] [--stats] [--no-read-cache] [--no-write-cache] [directory]\n'
     printf '\n'
@@ -80,7 +117,7 @@ for arg in "$@"; do
         --help)       print_usage; exit 0 ;;
         --version)    printf '%s\n' "$ASIMOV_VERSION"; exit 0 ;;
         -*)
-            echo "asimov: unknown option '$arg'" >&2
+            msg_error "unknown option '$arg'"
             print_usage >&2
             exit 1
             ;;
@@ -97,7 +134,7 @@ readonly ASIMOV_NO_READ_CACHE
 readonly ASIMOV_NO_WRITE_CACHE
 
 if [[ -n "$ASIMOV_QUIET" && -n "$ASIMOV_VERBOSE" ]]; then
-    echo "asimov: --quiet and --verbose are mutually exclusive" >&2
+    msg_error "--quiet and --verbose are mutually exclusive"
     exit 1
 fi
 
@@ -105,26 +142,13 @@ fi
 readonly ASIMOV_KB_PER_MB=1024
 readonly ASIMOV_KB_PER_GB=1048576
 
-# Disable colors when stdout is not a terminal (e.g. launchd, pipes, redirects).
-if [[ -t 1 ]]; then
-    readonly ASIMOV_COLOR_INFO=$'\033[0;36m'
-    readonly ASIMOV_COLOR_SUCCESS=$'\033[0;32m'
-    readonly ASIMOV_COLOR_DIM=$'\033[0;90m'
-    readonly ASIMOV_COLOR_RESET=$'\033[0m'
-else
-    readonly ASIMOV_COLOR_INFO=''
-    readonly ASIMOV_COLOR_SUCCESS=''
-    readonly ASIMOV_COLOR_DIM=''
-    readonly ASIMOV_COLOR_RESET=''
-fi
-
 # Print a dim timestamped debug line when --verbose is set.
 # Uses bash's built-in $SECONDS variable (auto-increments from 0 at script start).
 # Output goes to stderr so it stays visible even when stdout is redirected
 # (e.g. inside discover_new_paths_via_mdfind whose stdout is captured to a file).
 verbose_timing() {
     [[ -n "$ASIMOV_VERBOSE" ]] || return 0
-    printf '%s  [%ds] %s%s\n' "$ASIMOV_COLOR_DIM" "$SECONDS" "$1" "$ASIMOV_COLOR_RESET" >&2
+    printf '%s  [%ds] %s%s\n' "$ASIMOV_ERR_DIM" "$SECONDS" "$1" "$ASIMOV_ERR_RESET" >&2
 }
 
 # Resolve the root directory to scan (console user's home when running as root).
@@ -215,7 +239,7 @@ load_config
 ASIMOV_SCAN_DIRS=()
 if [[ -n "$ASIMOV_SCAN_DIR" ]]; then
     if [[ ! -d "$ASIMOV_SCAN_DIR" ]]; then
-        echo "asimov: not a directory: ${ASIMOV_SCAN_DIR}" >&2
+        msg_error "not a directory: ${ASIMOV_SCAN_DIR}"
         exit 1
     fi
     ASIMOV_SCAN_DIRS=("$ASIMOV_SCAN_DIR")
@@ -224,7 +248,7 @@ else
     for scan_dir in ${ASIMOV_CONFIG_SCAN_DIRS[@]+"${ASIMOV_CONFIG_SCAN_DIRS[@]}"}; do
         if [[ ! -d "$scan_dir" ]]; then
             [[ -z "$ASIMOV_QUIET" ]] && \
-                echo "asimov: configured scan directory does not exist, skipping: ${scan_dir}" >&2
+                msg_warn "configured scan directory does not exist — skipping: ${scan_dir}"
             continue
         fi
         ASIMOV_SCAN_DIRS+=("$scan_dir")
@@ -814,13 +838,13 @@ exclude_paths_from_stdin() {
         # "Error (-20)" / EINVAL. The common case is Go's module cache, which is
         # deliberately 0555. Check first: addexclusion costs ~11s even when it fails.
         if [[ ! -w "$path" ]]; then
-            echo "! ${path}: read-only, cannot be excluded — skipping." >&2
+            msg_warn "${path}: read-only, cannot be excluded — skipping."
             [[ -z "$ASIMOV_NO_WRITE_CACHE" ]] && printf '%s\n' "$path" >> "$ASIMOV_FAILED_STATE"
             continue
         fi
         # tmutil prints its POSIXError dump to stdout, not stderr — silence both.
         if ! tmutil addexclusion "${path}" >/dev/null 2>&1; then
-            echo "! ${path}: failed to exclude (tmutil error), skipping." >&2
+            msg_warn "${path}: failed to exclude (tmutil error) — skipping."
             # Persist failure so we skip this path on subsequent runs.
             # Use --no-read-cache to retry.
             [[ -z "$ASIMOV_NO_WRITE_CACHE" ]] && printf '%s\n' "$path" >> "$ASIMOV_FAILED_STATE"
@@ -971,7 +995,7 @@ print_exclusion_summary() {
 # --- Main: build find params, run find (or use cache), process paths, then fixed dirs, then summary ---
 
 if [[ ! -d "$ASIMOV_ROOT" ]]; then
-    echo "asimov: root directory does not exist or is not a directory: $ASIMOV_ROOT" >&2
+    msg_error "root directory does not exist or is not a directory: $ASIMOV_ROOT"
     exit 1
 fi
 

--- a/tests/root_guard.bats
+++ b/tests/root_guard.bats
@@ -1,0 +1,124 @@
+#!/usr/bin/env bats
+#
+# Tests for the root/sudo guard and the styled error/warning messages.
+#
+# ASIMOV_TEST_UID simulates a root run; ASIMOV_TEST_INTERACTIVE simulates a
+# terminal so the confirmation prompt is reachable from a non-tty test run.
+
+load test_helper
+
+# Run asimov as simulated root, feeding $1 to the confirmation prompt.
+run_asimov_as_root() {
+  local answer="$1"
+  shift
+  run env ASIMOV_TEST_UID=0 ASIMOV_TEST_INTERACTIVE=1 \
+    bash -c "printf '%s\n' '${answer}' | '${BATS_TEST_DIRNAME}/../asimov' $*"
+}
+
+# =============================================================================
+# Root / sudo guard
+# =============================================================================
+
+@test "warns when running as root" {
+  create_project "Code/My-Project" "package.json" "node_modules"
+  ASIMOV_TEST_UID=0 run_asimov
+  [[ "$output" == *"running asimov as root (sudo)"* ]]
+}
+
+@test "root warning explains the better alternative" {
+  ASIMOV_TEST_UID=0 run_asimov
+  [[ "$output" == *"Do this instead:"* ]]
+  [[ "$output" == *"launchctl kickstart"* ]]
+  [[ "$output" == *"chown -R"* ]]
+}
+
+@test "continues without prompting when not interactive" {
+  create_project "Code/My-Project" "package.json" "node_modules"
+  ASIMOV_TEST_UID=0 run_asimov
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"Non-interactive session"* ]]
+  assert_excluded "${HOME}/Code/My-Project/node_modules"
+}
+
+@test "aborts when the root confirmation is declined" {
+  create_project "Code/My-Project" "package.json" "node_modules"
+  run_asimov_as_root "n"
+  [[ "$status" -eq 1 ]]
+  [[ "$output" == *"aborted"* ]]
+  refute_excluded "${HOME}/Code/My-Project/node_modules"
+}
+
+@test "aborts when the root confirmation is answered with a bare newline" {
+  create_project "Code/My-Project" "package.json" "node_modules"
+  run_asimov_as_root ""
+  [[ "$status" -eq 1 ]]
+  refute_excluded "${HOME}/Code/My-Project/node_modules"
+}
+
+@test "proceeds when the root confirmation is accepted" {
+  create_project "Code/My-Project" "package.json" "node_modules"
+  run_asimov_as_root "y"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"continuing as root"* ]]
+  assert_excluded "${HOME}/Code/My-Project/node_modules"
+}
+
+@test "accepts a spelled-out yes at the root confirmation" {
+  create_project "Code/My-Project" "package.json" "node_modules"
+  run_asimov_as_root "YES"
+  [[ "$status" -eq 0 ]]
+  assert_excluded "${HOME}/Code/My-Project/node_modules"
+}
+
+@test "ASIMOV_ALLOW_ROOT skips the warning entirely" {
+  create_project "Code/My-Project" "package.json" "node_modules"
+  ASIMOV_TEST_UID=0 ASIMOV_ALLOW_ROOT=1 run_asimov
+  [[ "$status" -eq 0 ]]
+  [[ "$output" != *"running asimov as root"* ]]
+  assert_excluded "${HOME}/Code/My-Project/node_modules"
+}
+
+@test "does not warn on a normal (non-root) run" {
+  create_project "Code/My-Project" "package.json" "node_modules"
+  run_asimov
+  [[ "$output" != *"running asimov as root"* ]]
+}
+
+@test "warns before doing any work in --dry-run too" {
+  create_project "Code/My-Project" "package.json" "node_modules"
+  run_asimov_as_root "n" --dry-run
+  [[ "$status" -eq 1 ]]
+  [[ "$output" == *"running asimov as root (sudo)"* ]]
+}
+
+# =============================================================================
+# Styled diagnostics
+# =============================================================================
+
+@test "errors are prefixed with the error marker" {
+  run_asimov --bogus-option
+  [[ "$status" -eq 1 ]]
+  [[ "$output" == *"✗ asimov: unknown option '--bogus-option'"* ]]
+}
+
+@test "conflicting flags produce a styled error" {
+  run_asimov --quiet --verbose
+  [[ "$status" -eq 1 ]]
+  [[ "$output" == *"✗ asimov: --quiet and --verbose are mutually exclusive"* ]]
+}
+
+@test "a missing scan directory produces a styled error" {
+  run_asimov "${HOME}/does-not-exist"
+  [[ "$status" -eq 1 ]]
+  [[ "$output" == *"✗ asimov: not a directory:"* ]]
+}
+
+@test "the root warning uses the warning marker" {
+  ASIMOV_TEST_UID=0 run_asimov
+  [[ "$output" == *"⚠ asimov: you are running asimov as root"* ]]
+}
+
+@test "diagnostics carry no ANSI codes when stderr is not a terminal" {
+  run_asimov --bogus-option
+  [[ "$output" != *$'\033['* ]]
+}


### PR DESCRIPTION
## What

Two related changes to what Asimov prints when something is wrong, plus a guard against `sudo asimov`.

### 1. Styled diagnostics (`refactor`)

Progress output was colored; errors and warnings went out as bare `echo … >&2`. They now route through `msg_error` (red `✗`), `msg_warn` (yellow `⚠`) and `msg_hint` (dim, indented continuation).

Colors for stderr are gated on **stderr's** own `-t 2` check rather than stdout's, so `asimov > log.txt` no longer strips codes from diagnostics still going to the terminal — and `asimov 2>&1 | tee` no longer leaks them the other way.

### 2. Root/sudo guard (`feat`)

```
⚠ asimov: you are running asimov as root (sudo). That is almost never what you want.

  Time Machine stores each exclusion as an xattr on the directory itself, so
  root gains you nothing — but it does leave ~/.cache/asimov owned by root,
  which breaks your next normal run.

  Do this instead:
      asimov                                                    # run it as yourself
      launchctl kickstart gui/$(id -u)/com.stevegrunwell.asimov  # or let the agent do it

  Already ran it with sudo? Fix the ownership with:
      sudo chown -R "$(whoami)" ~/.cache/asimov

  Continue as root anyway? [y/N]
```

- Declining (or a bare newline) exits `1` **before any work happens**, including under `--dry-run`.
- **Non-interactive** runs — launchd, CI, cron — warn and continue, so no existing root automation breaks.
- `ASIMOV_ALLOW_ROOT=1` skips the check entirely.

### 3. Worktree workflow (`docs`)

CONTRIBUTING now documents working on a git worktree per change, with the add/remove/prune commands.

## Testing

`tests/root_guard.bats` — 15 tests covering the guard (warn, decline, accept, `YES`, bare newline, `--dry-run`, non-interactive, `ASIMOV_ALLOW_ROOT`, non-root) and the styled diagnostics (markers on each error path, no ANSI codes when stderr is not a terminal).

`ASIMOV_TEST_UID` and `ASIMOV_TEST_INTERACTIVE` are test seams scoped to the guard only — the real `EUID` still drives root-home resolution and the cache `chown`, so a simulated-root test can never escape `$HOME`.

**172 tests pass under both bash 5.x (`make check`) and the macOS system bash 3.2 (`make test-system-bash`); ShellCheck clean.**

## Notes for review

- Warnings are intentionally **not** suppressed by `--quiet` (documented as "suppress all output except errors") — a root run is not routine output.
- The color block moved above argument parsing, since the first errors (`unknown option`, `--quiet --verbose`) happen there.
