### PR TITLE
docs(readme): add a "What Asimov doesn't do" section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   most users get — `asimov` starts with `#!/usr/bin/env bash`, and a development machine
   usually has 5.x first on `PATH`. `make test BASH_BIN=<path>` pins any interpreter, and
   `make test BATS_JOBS=N` runs tests concurrently (needs GNU parallel).
+- README: a "What Asimov doesn't do" section, covering the three things Asimov is most
+  often expected to do and doesn't — hide directories from Spotlight (a separate mechanism
+  from Time Machine exclusions), shrink backups that already exist, and delete anything —
+  plus how to verify a run reached your projects
+  ([#90](https://github.com/AsimovMac/asimov/issues/90),
+  [#45](https://github.com/AsimovMac/asimov/issues/45)).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,31 @@ This means Asimov never touches a folder that just happens to share a common nam
 **Don't see your tool?** You can teach Asimov your own directory + sentinel pairs in a couple of lines — no need to wait for a release. See [Add your own patterns](#add-your-own-patterns).
 
 
+## What Asimov doesn't do
+
+Asimov sets **Time Machine exclusions** — nothing else. Three things it's often expected to do, and doesn't:
+
+| | |
+| --- | --- |
+| **Hide folders from Spotlight** | Spotlight indexing is a separate mechanism. Excluding `node_modules` from Time Machine does not stop it appearing in Spotlight results. Tracked in [#70](https://github.com/AsimovMac/asimov/issues/70) |
+| **Shrink existing backups** | An exclusion stops a directory being backed up *from now on*. Copies already on the backup disk stay until you delete them or Time Machine ages them out |
+| **Delete anything** | Asimov never removes a file from your Mac. It only sets an attribute on the directory |
+
+Nothing is lost by excluding a dependency directory: it isn't backed up, and after a restore you run `npm install` (or your equivalent) to get it back.
+
+### Verifying it worked
+
+```sh
+asimov --dry-run                                                   # what Asimov would exclude
+sudo mdfind "com_apple_backup_excludeItem = 'com.apple.backupd'"   # what's actually excluded
+```
+
+If `mdfind` doesn't list your projects, the run isn't reaching them. The two usual causes:
+
+- **Projects live outside your home directory.** Add them with [`[scan] extra`](#scan-more-than-your-home-directory).
+- **The schedule isn't loaded.** Check with `launchctl print gui/$(id -u)/com.stevegrunwell.asimov`, and see [Schedule](#schedule).
+
+
 ## Usage
 
 ```


### PR DESCRIPTION
Three questions come up repeatedly in the issue tracker, all from the same root cause: Asimov sets Time Machine exclusions and people reasonably assume it does more.

This adds a short section after **How it works** covering what it doesn't do:

- **Hide folders from Spotlight** — a separate mechanism entirely (#70 tracks adding it)
- **Shrink existing backups** — an exclusion is forward-looking; old copies stay on the disk
- **Delete anything** — it only sets an attribute

Plus a two-command verification recipe, and the two usual reasons a run doesn't reach someone's projects: projects outside `$HOME`, and the schedule not being loaded.

Closes #90. Unblocks #45, which was kept open pending exactly this.