### PR TITLE
feat(prune): add an `asimov prune` subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   most users get — `asimov` starts with `#!/usr/bin/env bash`, and a development machine
   usually has 5.x first on `PATH`. `make test BASH_BIN=<path>` pins any interpreter, and
   `make test BATS_JOBS=N` runs tests concurrently (needs GNU parallel).
+- `asimov prune` reports Time Machine exclusions whose directory no longer exists, and
+  compacts Asimov's own path cache. It is read-only with respect to Time Machine: stale
+  entries live in the system-wide "sticky" list (`tmutil addexclusion -p`), which Asimov
+  never writes, so `prune` prints the `sudo tmutil removeexclusion -p` command rather than
+  running it. Asimov's own exclusions are stored as an attribute on the directory itself
+  and are therefore removed automatically when the directory is deleted — only sticky
+  entries can outlive their directory ([#38](https://github.com/AsimovMac/asimov/issues/38)).
 - README: a "What Asimov doesn't do" section, covering the three things Asimov is most
   often expected to do and doesn't — hide directories from Spotlight (a separate mechanism
   from Time Machine exclusions), shrink backups that already exist, and delete anything —

--- a/README.md
+++ b/README.md
@@ -144,6 +144,35 @@ asimov [--dry-run] [--verbose] [--quiet] [--stats] [--no-read-cache] [--no-write
 | `--no-read-cache`   | Ignore cached state; re-discover and re-verify everything, then rebuild the cache |
 | `--no-write-cache`  | Run normally but don't persist any cache updates                 |
 
+### `asimov prune`
+
+Reports Time Machine exclusions that point at a directory which no longer exists, and compacts Asimov's own cache.
+
+```
+$ asimov prune
+
+Stale Time Machine exclusions (1):
+  ~/Downloads/old-client  path no longer exists
+
+These are sticky exclusions (tmutil addexclusion -p), which Asimov never sets.
+They persist after the directory is deleted. To remove one:
+
+  sudo tmutil removeexclusion -p ~/Downloads/old-client
+
+Asimov cache: 3 stale entries dropped.
+```
+
+`prune` is **read-only** with respect to Time Machine — it prints the removal command rather than running it, since these entries are system-wide and Asimov didn't create them. The only file it writes is its own cache.
+
+Worth knowing why the distinction exists: Time Machine has two kinds of exclusion.
+
+| | Where it's stored | Survives deleting the directory? |
+| --- | --- | --- |
+| `tmutil addexclusion PATH` — what Asimov uses | An attribute on the directory itself | **No** — removed with it |
+| `tmutil addexclusion -p PATH` — "sticky" | Time Machine's system preferences | **Yes** — forever |
+
+So Asimov's own exclusions clean themselves up. Only sticky entries, set by other tools or by hand, can outlive their directory — and nothing else surfaces them.
+
 Asimov keeps a cache under `~/.cache/asimov/` so repeat runs are near-instant. The two flags above control it on independent axes — reading and writing:
 
 - `--no-read-cache` — *"rebuild."* Ignores everything cached, re-scans the filesystem, and re-verifies every directory against Time Machine, then writes a fresh cache. **`--full-scan` is an alias.**

--- a/asimov
+++ b/asimov
@@ -31,8 +31,14 @@ readonly ASIMOV_VERSION='0.10.0'
 
 print_usage() {
     printf 'Usage: asimov [--dry-run] [--verbose] [--quiet] [--stats] [--no-read-cache] [--no-write-cache] [directory]\n'
+    printf '       asimov prune [--quiet]\n'
     printf '\n'
     printf 'Exclude development dependency directories from Time Machine backups.\n'
+    printf '\n'
+    printf 'Commands:\n'
+    printf '  prune              Report Time Machine exclusions whose directory no longer\n'
+    printf '                     exists, and compact Asimov'\''s own cache. Read-only:\n'
+    printf '                     it prints the removal command rather than running it\n'
     printf '\n'
     printf 'Options:\n'
     printf '  --dry-run          Print what would be excluded without changing Time Machine\n'
@@ -65,6 +71,16 @@ ASIMOV_STATS=
 ASIMOV_NO_READ_CACHE=
 ASIMOV_NO_WRITE_CACHE=
 ASIMOV_SCAN_DIR=
+
+# Subcommands are recognised only as the first argument, so that a directory
+# sharing the name stays reachable as `asimov ./prune`.
+ASIMOV_COMMAND=scan
+if [[ "${1:-}" == "prune" ]]; then
+    ASIMOV_COMMAND=prune
+    shift
+fi
+readonly ASIMOV_COMMAND
+
 for arg in "$@"; do
     case "$arg" in
         --dry-run)    ASIMOV_DRY_RUN=1 ;;
@@ -151,6 +167,136 @@ readonly ASIMOV_ROOT
 readonly ASIMOV_EXCLUDED_STATE="${ASIMOV_ROOT}/.cache/asimov/excluded"
 readonly ASIMOV_FAILED_STATE="${ASIMOV_ROOT}/.cache/asimov/failed"
 readonly ASIMOV_MDFIND_SEEN="${ASIMOV_ROOT}/.cache/asimov/mdfind_seen"
+readonly ASIMOV_PATH_CACHE="${ASIMOV_ROOT}/.cache/asimov/paths"
+
+# Time Machine's system preferences, home of the "sticky" path exclusion list
+# (tmutil addexclusion -p). Overridable so tests can point at a fixture.
+readonly ASIMOV_TM_PLIST="${ASIMOV_TM_PLIST:-/Library/Preferences/com.apple.TimeMachine.plist}"
+
+# --- prune ---
+#
+# Asimov's own exclusions cannot go stale. `tmutil addexclusion PATH` stores the
+# exclusion as an extended attribute on the directory itself, so deleting the
+# directory deletes the exclusion with it.
+#
+# What *does* go stale is the "sticky" list: `tmutil addexclusion -p PATH` records
+# the path in Time Machine's system preferences instead, and that entry survives
+# the directory forever. Asimov has never written to that list, but other tools
+# and manual commands do, and nothing surfaces the leftovers.
+
+# Resolve a "~user/…" path, as stored in Time Machine's preferences, to an
+# absolute one. Falls back to /Users/<name> when the account can't be read.
+expand_tm_path() {
+    local path="$1" user rest home
+    case "$path" in
+        '~'*) ;;
+        *) printf '%s\n' "$path"; return 0 ;;
+    esac
+    path="${path#\~}"
+    user="${path%%/*}"
+    rest="${path#"$user"}"
+    if [[ -z "$user" ]]; then
+        printf '%s\n' "${ASIMOV_ROOT}${rest}"
+        return 0
+    fi
+    home="$(dscl . -read "/Users/${user}" NFSHomeDirectory 2>/dev/null | sed -n 's/^NFSHomeDirectory: //p')"
+    [[ -n "$home" ]] || home="/Users/${user}"
+    printf '%s\n' "${home}${rest}"
+}
+
+# Print the sticky exclusion list, one raw path per line.
+# `defaults` renders it as a plist array; strip the parentheses, indentation,
+# trailing commas, and surrounding quotes.
+read_sticky_exclusions() {
+    [[ -r "$ASIMOV_TM_PLIST" ]] || return 0
+    defaults read "${ASIMOV_TM_PLIST%.plist}" SkipPaths 2>/dev/null \
+        | sed -e '/^[[:space:]]*[()]/d' \
+              -e 's/^[[:space:]]*//' \
+              -e 's/[[:space:]]*,$//' \
+              -e 's/^"//' -e 's/"$//' \
+        | grep -v '^$' || true
+}
+
+# Drop entries whose directory no longer exists from Asimov's path cache.
+# Echoes the number of entries removed. This only ever touches Asimov's own
+# file under ~/.cache/asimov.
+prune_path_cache() {
+    [[ -f "$ASIMOV_PATH_CACHE" ]] || { echo 0; return 0; }
+
+    # A brace group with a redirect runs in the current shell, so the counters
+    # below survive the loop.
+    local tmp line dropped=0
+    tmp="${ASIMOV_PATH_CACHE}.tmp.$$"
+    {
+        printf '# asimov path cache — updated %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+        while IFS= read -r line; do
+            [[ "$line" =~ ^# ]] && continue
+            [[ -z "$line" ]] && continue
+            if [[ -d "$line" ]]; then
+                printf '%s\n' "$line"
+            else
+                dropped=$((dropped + 1))
+            fi
+        done < "$ASIMOV_PATH_CACHE"
+    } > "$tmp"
+
+    mv -f "$tmp" "$ASIMOV_PATH_CACHE"
+    echo "$dropped"
+}
+
+cmd_prune() {
+    local raw expanded sticky_total=0
+    local stale_paths="" stale_count=0
+
+    while IFS= read -r raw; do
+        sticky_total=$((sticky_total + 1))
+        expanded="$(expand_tm_path "$raw")"
+        if [[ ! -e "$expanded" ]]; then
+            stale_count=$((stale_count + 1))
+            stale_paths="${stale_paths}${raw}"$'\n'
+        fi
+    done < <(read_sticky_exclusions)
+
+    local cache_dropped
+    cache_dropped="$(prune_path_cache)"
+
+    [[ -n "$ASIMOV_QUIET" ]] && return 0
+
+    if [[ "$stale_count" -gt 0 ]]; then
+        printf '\n%sStale Time Machine exclusions (%s):%s\n' \
+            "$ASIMOV_COLOR_INFO" "$stale_count" "$ASIMOV_COLOR_RESET"
+        printf '%s' "$stale_paths" | while IFS= read -r raw; do
+            [[ -z "$raw" ]] && continue
+            printf '  %s %spath no longer exists%s\n' \
+                "$raw" "$ASIMOV_COLOR_DIM" "$ASIMOV_COLOR_RESET"
+        done
+        printf '\nThese are sticky exclusions (%stmutil addexclusion -p%s), which Asimov never sets.\n' \
+            "$ASIMOV_COLOR_DIM" "$ASIMOV_COLOR_RESET"
+        printf 'They persist after the directory is deleted. To remove one:\n\n'
+        printf '  sudo tmutil removeexclusion -p %s\n\n' "$(printf '%s' "$stale_paths" | head -1)"
+    elif [[ "$sticky_total" -gt 0 ]]; then
+        printf '\n%s✓%s No stale exclusions. All %s sticky entries point at directories that exist.\n' \
+            "$ASIMOV_COLOR_SUCCESS" "$ASIMOV_COLOR_RESET" "$sticky_total"
+    else
+        printf '\n%s✓%s No sticky Time Machine exclusions are set on this Mac.\n' \
+            "$ASIMOV_COLOR_SUCCESS" "$ASIMOV_COLOR_RESET"
+    fi
+
+    if [[ "$cache_dropped" -gt 0 ]]; then
+        printf 'Asimov cache: %s stale %s dropped.\n' \
+            "$cache_dropped" "$([[ "$cache_dropped" -eq 1 ]] && echo entry || echo entries)"
+    else
+        printf 'Asimov cache: nothing to prune.\n'
+    fi
+
+    printf '\n%sAsimov'\''s own exclusions are stored on the directory itself, so they are\nremoved automatically when you delete it — only sticky entries can outlive it.%s\n' \
+        "$ASIMOV_COLOR_DIM" "$ASIMOV_COLOR_RESET"
+}
+
+if [[ "$ASIMOV_COMMAND" == "prune" ]]; then
+    cmd_prune
+    exit 0
+fi
 
 # Load optional config from ~/.config/asimov/config.
 # Populates ASIMOV_CONFIG_* variables. Missing file is silently ignored.
@@ -293,7 +439,8 @@ fi
 verbose_timing "Excluded-path cache ready ($(wc -l < "$ASIMOV_EXCLUDED_CACHE" | tr -d ' ') entries, ${spotlight_count} from Spotlight)"
 
 # --- Path cache ---
-readonly ASIMOV_PATH_CACHE="${ASIMOV_ROOT}/.cache/asimov/paths"
+# (ASIMOV_PATH_CACHE is defined alongside the other state files, above, so that
+# the prune subcommand can reach it before any of the scan machinery runs.)
 
 # Create the cache directory, chown to console user when running as root.
 ensure_cache_dir() {

--- a/tests/behavior.bats
+++ b/tests/behavior.bats
@@ -734,3 +734,91 @@ extra = ${HOME}/Code"
   [[ "$(count_exclusions)" -eq 1 ]]
   refute_excluded "${HOME}/Projects/app/node_modules"
 }
+
+# --- prune ---
+
+@test "prune reports a sticky exclusion whose directory no longer exists" {
+  mkdir -p "${HOME}/Keep"
+  write_sticky_exclusions "${HOME}/Keep" "${HOME}/Deleted"
+
+  run_asimov prune
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"Stale Time Machine exclusions (1)"* ]]
+  [[ "$output" == *"${HOME}/Deleted"* ]]
+  [[ "$output" != *"${HOME}/Keep "* ]]
+}
+
+@test "prune prints the removal command rather than running it" {
+  write_sticky_exclusions "${HOME}/Deleted"
+
+  run_asimov prune
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"sudo tmutil removeexclusion -p ${HOME}/Deleted"* ]]
+  # Read-only: the mock tmutil database is untouched.
+  [[ "$(count_exclusions)" -eq 0 ]]
+}
+
+@test "prune reports a clean bill of health when every sticky entry exists" {
+  mkdir -p "${HOME}/Keep"
+  write_sticky_exclusions "${HOME}/Keep"
+
+  run_asimov prune
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"No stale exclusions"* ]]
+  [[ "$output" == *"1 sticky entries"* ]]
+}
+
+@test "prune handles a Mac with no sticky exclusions at all" {
+  export ASIMOV_TM_PLIST="${TEST_TEMP_DIR}/missing.plist"
+
+  run_asimov prune
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"No sticky Time Machine exclusions"* ]]
+}
+
+@test "prune drops cache entries whose directory is gone and keeps the rest" {
+  mkdir -p "${HOME}/Projects/app/node_modules"
+  write_path_cache "${HOME}/Projects/app/node_modules" "${HOME}/Projects/gone/node_modules"
+
+  run_asimov prune
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"Asimov cache: 1 stale entry dropped."* ]]
+  assert_cached "${HOME}/Projects/app/node_modules"
+  refute_cached "${HOME}/Projects/gone/node_modules"
+}
+
+@test "prune says so when the cache has nothing to drop" {
+  mkdir -p "${HOME}/Projects/app/node_modules"
+  write_path_cache "${HOME}/Projects/app/node_modules"
+
+  run_asimov prune
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"Asimov cache: nothing to prune."* ]]
+}
+
+@test "prune --quiet prints nothing but still compacts the cache" {
+  write_sticky_exclusions "${HOME}/Deleted"
+  mkdir -p "${HOME}/Projects/app/node_modules"
+  write_path_cache "${HOME}/Projects/app/node_modules" "${HOME}/Projects/gone/node_modules"
+
+  run_asimov prune --quiet
+  [[ "$status" -eq 0 ]]
+  [[ -z "$output" ]]
+  refute_cached "${HOME}/Projects/gone/node_modules"
+  assert_cached "${HOME}/Projects/app/node_modules"
+}
+
+@test "prune is listed in the help output" {
+  run_asimov --help
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"asimov prune"* ]]
+}
+
+@test "a directory named prune is still scannable as a path" {
+  mkdir -p "${HOME}/prune/app/node_modules"
+  echo "sentinel" > "${HOME}/prune/app/package.json"
+
+  run_asimov --dry-run "${HOME}/prune"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"Would exclude: ${HOME}/prune/app/node_modules"* ]]
+}

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -185,3 +185,19 @@ refute_failed() {
 load_format_size_kb() {
     eval "$(awk '/^readonly ASIMOV_KB_PER/; /^format_size_kb\(\)/,/^}/' "${BATS_TEST_DIRNAME}/../asimov")"
 }
+
+# Write a Time Machine preferences fixture holding a sticky exclusion list
+# (the SkipPaths array written by `tmutil addexclusion -p`), and point the
+# script at it via ASIMOV_TM_PLIST.
+#
+# Usage: write_sticky_exclusions "/path/one" "/path/two"
+write_sticky_exclusions() {
+    local plist="${TEST_TEMP_DIR}/com.apple.TimeMachine.plist"
+    local path
+    /usr/libexec/PlistBuddy -c "Add :SkipPaths array" "$plist" >/dev/null 2>&1 \
+        || /usr/libexec/PlistBuddy -c "Delete :SkipPaths" -c "Add :SkipPaths array" "$plist" >/dev/null 2>&1
+    for path in "$@"; do
+        /usr/libexec/PlistBuddy -c "Add :SkipPaths: string ${path}" "$plist" >/dev/null
+    done
+    export ASIMOV_TM_PLIST="$plist"
+}


### PR DESCRIPTION
Closes #38.

## The finding first

#38 asked for a way to purge exclusions left behind after deleting a project. Investigating it, the premise doesn't hold for Asimov's own work — and that shaped the whole design.

Time Machine has two exclusion mechanisms:

| | Where it's stored | Survives deleting the directory? |
| --- | --- | --- |
| `tmutil addexclusion PATH` — **what Asimov uses** | An extended attribute on the directory | **No** — removed with it |
| `tmutil addexclusion -p PATH` — "sticky" | `/Library/Preferences/com.apple.TimeMachine.plist` | **Yes** — forever |

`git log -S` confirms Asimov has **never** used `-p`, in any version. So Asimov's exclusions self-clean, and `finalize_path_cache()` already drops missing directories from the local cache on every run.

The real problem is the sticky list — which Asimov never writes, but other tools and manual commands do. Those entries are invisible and permanent. On my own Mac the list has 5 entries, none of which any tool surfaces.

## What this adds

`asimov prune` checks both, and is **read-only with respect to Time Machine**:

```
$ asimov prune

Stale Time Machine exclusions (1):
  ~/Downloads/old-client  path no longer exists

These are sticky exclusions (tmutil addexclusion -p), which Asimov never sets.
They persist after the directory is deleted. To remove one:

  sudo tmutil removeexclusion -p ~/Downloads/old-client

Asimov cache: 3 stale entries dropped.
```

It prints the removal command rather than running it. These entries are system-wide, need `sudo`, and Asimov didn't create them — deleting them silently would be overreach. The only file it writes is its own cache under `~/.cache/asimov`.

## Notes

- Subcommands are recognised **only as the first argument**, so a directory named `prune` stays reachable as `asimov ./prune`. There's a test for it.
- The plist is world-readable, so detection needs no `sudo`.
- `~user/…` paths in the plist are resolved via `dscl`, falling back to `/Users/<name>`.
- `ASIMOV_TM_PLIST` lets the suite point at a fixture instead of the real file.

## Testing

9 new tests. Full suite **181 passing**, ShellCheck clean, verified against real system state.