### PR TITLE
feat(spotlight): exclude discovered directories from Spotlight, independently of Time Machine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,15 +25,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   plus how to verify a run reached your projects
   ([#90](https://github.com/AsimovMac/asimov/issues/90),
   [#45](https://github.com/AsimovMac/asimov/issues/45)).
-- `--spotlight` reports the same discovered dependency directories as candidates to
-  exclude from Spotlight indexing, independently of Time Machine exclusion — a directory
-  can be excluded from either, both, or neither. Asimov cannot read or write macOS's
-  Spotlight Privacy list without root and never runs as root (including unattended via
-  the LaunchAgent, where nothing could enter a sudo password), so it never touches
-  Spotlight state itself: it prints one batched `sudo plutil` command covering every new
-  candidate from the run, plus the `sudo killall mds` needed to make Spotlight pick up
-  the change, the same "print, don't act" precedent `asimov prune` already set for
-  privileged state it doesn't own ([#70](https://github.com/AsimovMac/asimov/issues/70)).
+- `--spotlight` also excludes the same discovered dependency directories from Spotlight
+  indexing, independently of Time Machine exclusion — a directory can be excluded from
+  either, both, or neither. Excluding requires root, since macOS only allows root to read
+  or write the Spotlight Privacy list, so `sudo asimov --spotlight` applies the exclusions
+  directly (and restarts Spotlight's metadata server to pick them up); running without
+  `sudo` changes nothing and prints a warning explaining why root is required, and
+  `--dry-run --spotlight` previews candidates without needing root at all
+  ([#70](https://github.com/AsimovMac/asimov/issues/70)).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   or write the Spotlight Privacy list, so `sudo asimov --spotlight` applies the exclusions
   directly (and restarts Spotlight's metadata server to pick them up); running without
   `sudo` changes nothing and prints a warning explaining why root is required, and
-  `--dry-run --spotlight` previews candidates without needing root at all
+  `--dry-run --spotlight` previews candidates without needing root at all. Note that the
+  scheduled LaunchAgent run (see `## Schedule` in the README) always runs unprivileged, so
+  it never applies Spotlight exclusions on its own — only `sudo asimov --spotlight`, run
+  manually, does. Time Machine exclusion is unaffected and stays fully automated
   ([#70](https://github.com/AsimovMac/asimov/issues/70)).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   plus how to verify a run reached your projects
   ([#90](https://github.com/AsimovMac/asimov/issues/90),
   [#45](https://github.com/AsimovMac/asimov/issues/45)).
+- `--spotlight` reports the same discovered dependency directories as candidates to
+  exclude from Spotlight indexing, independently of Time Machine exclusion — a directory
+  can be excluded from either, both, or neither. Asimov cannot read or write macOS's
+  Spotlight Privacy list without root and never runs as root (including unattended via
+  the LaunchAgent, where nothing could enter a sudo password), so it never touches
+  Spotlight state itself: it prints one batched `sudo plutil` command covering every new
+  candidate from the run, plus the `sudo killall mds` needed to make Spotlight pick up
+  the change, the same "print, don't act" precedent `asimov prune` already set for
+  privileged state it doesn't own ([#70](https://github.com/AsimovMac/asimov/issues/70)).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Asimov's default behavior sets **Time Machine exclusions** — nothing else. Two
 
 | | |
 | --- | --- |
-| **Hide folders from Spotlight** | Spotlight indexing is a separate mechanism from Time Machine exclusion, and off by default. Pass `--spotlight` to have Asimov report the same discovered directories as Spotlight-exclusion candidates — it prints the `sudo` command to run yourself rather than touching Spotlight state itself. See [`--spotlight`](#usage) |
+| **Hide folders from Spotlight** | Spotlight indexing is a separate mechanism from Time Machine exclusion, and off by default. Pass `--spotlight` to have Asimov also exclude the same discovered directories from Spotlight. Excluding requires root, so run with `sudo` to apply it; without `sudo` Asimov reports what it would exclude and explains why it needs root. See [`--spotlight`](#usage) |
 | **Shrink existing backups** | An exclusion stops a directory being backed up *from now on*. Copies already on the backup disk stay until you delete them or Time Machine ages them out |
 | **Delete anything** | Asimov never removes a file from your Mac. It only sets an attribute on the directory |
 
@@ -141,7 +141,7 @@ asimov [--dry-run] [--verbose] [--quiet] [--stats] [--spotlight] [--no-read-cach
 | `--verbose`         | Show all directories including already-excluded ones             |
 | `--quiet`           | Suppress all output except errors                                |
 | `--stats`           | Show per-directory sizes and a total-space summary               |
-| `--spotlight`       | Also report directories to exclude from Spotlight — prints a `sudo plutil`/`killall mds` command to run yourself; independent of Time Machine exclusion |
+| `--spotlight`       | Also exclude directories from Spotlight, independently of Time Machine exclusion. Requires root — run with `sudo` to apply, or without it to see what would be excluded and why root is needed. Works without root under `--dry-run` |
 | `--no-read-cache`   | Ignore cached state; re-discover and re-verify everything, then rebuild the cache |
 | `--no-write-cache`  | Run normally but don't persist any cache updates                 |
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ asimov [--dry-run] [--verbose] [--quiet] [--stats] [--spotlight] [--no-read-cach
 | `--verbose`         | Show all directories including already-excluded ones             |
 | `--quiet`           | Suppress all output except errors                                |
 | `--stats`           | Show per-directory sizes and a total-space summary               |
-| `--spotlight`       | Also exclude directories from Spotlight, independently of Time Machine exclusion. Requires root — run with `sudo` to apply, or without it to see what would be excluded and why root is needed. Works without root under `--dry-run` |
+| `--spotlight`       | Also exclude directories from Spotlight, independently of Time Machine exclusion. Requires root — run with `sudo` to apply, or without it to see what would be excluded and why root is needed. Works without root under `--dry-run`. Not applied by the [scheduled run](#schedule) — that runs unprivileged |
 | `--no-read-cache`   | Ignore cached state; re-discover and re-verify everything, then rebuild the cache |
 | `--no-write-cache`  | Run normally but don't persist any cache updates                 |
 
@@ -189,6 +189,8 @@ The curl and source installers set up a daily launchd job automatically. To trig
 launchctl kickstart gui/$(id -u)/com.stevegrunwell.asimov   # run now
 launchctl bootout   gui/$(id -u)/com.stevegrunwell.asimov   # stop schedule
 ```
+
+This LaunchAgent runs as your regular (unprivileged) user, the same as a per-user cron job would — it has no `UserName`/`GroupName` override, so it never runs as root. That's fine for Time Machine exclusion, which the schedule fully automates. It means `--spotlight` exclusions are **not** kept up to date automatically: applying them needs root (see [`--spotlight`](#usage)), and a scheduled run can't supply a `sudo` password unattended, so it just reports what it would exclude without applying it. If you use `--spotlight`, periodically run `sudo asimov --spotlight` yourself to pick up newly discovered directories.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -105,11 +105,11 @@ This means Asimov never touches a folder that just happens to share a common nam
 
 ## What Asimov doesn't do
 
-Asimov sets **Time Machine exclusions** — nothing else. Three things it's often expected to do, and doesn't:
+Asimov's default behavior sets **Time Machine exclusions** — nothing else. Two things it's often expected to do, and doesn't, plus one it can help with when asked:
 
 | | |
 | --- | --- |
-| **Hide folders from Spotlight** | Spotlight indexing is a separate mechanism. Excluding `node_modules` from Time Machine does not stop it appearing in Spotlight results. Tracked in [#70](https://github.com/AsimovMac/asimov/issues/70) |
+| **Hide folders from Spotlight** | Spotlight indexing is a separate mechanism from Time Machine exclusion, and off by default. Pass `--spotlight` to have Asimov report the same discovered directories as Spotlight-exclusion candidates — it prints the `sudo` command to run yourself rather than touching Spotlight state itself. See [`--spotlight`](#usage) |
 | **Shrink existing backups** | An exclusion stops a directory being backed up *from now on*. Copies already on the backup disk stay until you delete them or Time Machine ages them out |
 | **Delete anything** | Asimov never removes a file from your Mac. It only sets an attribute on the directory |
 
@@ -131,7 +131,7 @@ If `mdfind` doesn't list your projects, the run isn't reaching them. The two usu
 ## Usage
 
 ```
-asimov [--dry-run] [--verbose] [--quiet] [--stats] [--no-read-cache] [--no-write-cache] [--help] [--version]
+asimov [--dry-run] [--verbose] [--quiet] [--stats] [--spotlight] [--no-read-cache] [--no-write-cache] [--help] [--version]
 ```
 
 
@@ -141,6 +141,7 @@ asimov [--dry-run] [--verbose] [--quiet] [--stats] [--no-read-cache] [--no-write
 | `--verbose`         | Show all directories including already-excluded ones             |
 | `--quiet`           | Suppress all output except errors                                |
 | `--stats`           | Show per-directory sizes and a total-space summary               |
+| `--spotlight`       | Also report directories to exclude from Spotlight — prints a `sudo plutil`/`killall mds` command to run yourself; independent of Time Machine exclusion |
 | `--no-read-cache`   | Ignore cached state; re-discover and re-verify everything, then rebuild the cache |
 | `--no-write-cache`  | Run normally but don't persist any cache updates                 |
 

--- a/asimov
+++ b/asimov
@@ -10,8 +10,7 @@ ASIMOV_SIZE_LOG="$(mktemp)"
 ASIMOV_EXCLUDED_CACHE="$(mktemp)"
 ASIMOV_PATH_CACHE_TMP=""
 # Accumulates new Spotlight-exclusion candidates across every call site in this
-# run, so the batched `plutil`/`killall mds` command is printed once at the end
-# instead of once per call site.
+# run, so they're applied (or reported) once at the end instead of once per call site.
 ASIMOV_SPOTLIGHT_CANDIDATES="$(mktemp)"
 trap 'rm -f "$ASIMOV_SIZE_LOG" "$ASIMOV_EXCLUDED_CACHE" "$ASIMOV_PATH_CACHE_TMP" "$ASIMOV_SPOTLIGHT_CANDIDATES"' EXIT
 
@@ -49,9 +48,11 @@ print_usage() {
     printf '  --verbose          Show all directories including already-excluded ones\n'
     printf '  --quiet            Suppress all output except errors\n'
     printf '  --stats            Show directory sizes and total space in the summary\n'
-    printf '  --spotlight        Also report directories to exclude from Spotlight (prints a\n'
-    printf '                     sudo command to run yourself — Asimov never touches Spotlight\n'
-    printf '                     state, and this is independent of Time Machine exclusion)\n'
+    printf '  --spotlight        Also exclude discovered directories from Spotlight, independently\n'
+    printf '                     of Time Machine exclusion. Requires root (macOS only allows root\n'
+    printf '                     to touch the Spotlight Privacy list) — run with sudo to apply;\n'
+    printf '                     without sudo, prints what would be excluded and why it needs root.\n'
+    printf '                     Works without root under --dry-run.\n'
     printf '  --no-read-cache    Ignore cached state; re-discover and re-verify everything (rebuilds the cache)\n'
     printf '  --no-write-cache   Run normally but do not persist any cache updates\n'
     printf '  --full-scan        Alias for --no-read-cache\n'
@@ -88,6 +89,11 @@ if [[ "${1:-}" == "prune" ]]; then
     shift
 fi
 readonly ASIMOV_COMMAND
+
+# Preserved so a --spotlight run that can't write (not root) can tell the user
+# exactly what to re-run with sudo.
+ASIMOV_ORIGINAL_ARGS=("$@")
+readonly ASIMOV_ORIGINAL_ARGS
 
 for arg in "$@"; do
     case "$arg" in
@@ -157,7 +163,7 @@ verbose_timing() {
 resolve_asimov_root() {
     if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
         local console_user
-        console_user="$(stat -f '%Su' /dev/console 2>/dev/null || echo '')"
+        console_user="$(/usr/bin/stat -f '%Su' /dev/console 2>/dev/null || echo '')"
         if [[ -n "$console_user" && "$console_user" != "root" ]]; then
             local root_dir
             root_dir="$(dscl . -read "/Users/${console_user}" NFSHomeDirectory 2>/dev/null | awk '{print $2}')"
@@ -188,6 +194,11 @@ readonly ASIMOV_SPOTLIGHT_STATE="${ASIMOV_ROOT}/.cache/asimov/spotlight_pending"
 # Time Machine's system preferences, home of the "sticky" path exclusion list
 # (tmutil addexclusion -p). Overridable so tests can point at a fixture.
 readonly ASIMOV_TM_PLIST="${ASIMOV_TM_PLIST:-/Library/Preferences/com.apple.TimeMachine.plist}"
+
+# Spotlight's Privacy exclusion list. Reading or writing it requires root —
+# unprivileged access fails even to read it. Overridable so tests can point at
+# a fixture plist without touching the real one.
+readonly ASIMOV_SPOTLIGHT_PLIST="${ASIMOV_SPOTLIGHT_PLIST:-/System/Volumes/Data/.Spotlight-V100/VolumeConfiguration.plist}"
 
 # --- prune ---
 #
@@ -465,7 +476,7 @@ ensure_cache_dir() {
     mkdir -p "$cache_dir"
     if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
         local console_user
-        console_user="$(stat -f '%Su' /dev/console 2>/dev/null || echo '')"
+        console_user="$(/usr/bin/stat -f '%Su' /dev/console 2>/dev/null || echo '')"
         if [[ -n "$console_user" && "$console_user" != "root" ]]; then
             chown -R "$console_user" "$cache_dir" 2>/dev/null || true
         fi
@@ -558,7 +569,7 @@ finalize_path_cache() {
 
     if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
         local console_user
-        console_user="$(stat -f '%Su' /dev/console 2>/dev/null || echo '')"
+        console_user="$(/usr/bin/stat -f '%Su' /dev/console 2>/dev/null || echo '')"
         if [[ -n "$console_user" && "$console_user" != "root" ]]; then
             chown "$console_user" "$ASIMOV_PATH_CACHE" 2>/dev/null || true
         fi
@@ -1014,17 +1025,12 @@ exclude_paths_from_array() {
     fi
 }
 
-# Report the given paths as Spotlight-exclusion candidates (only when --spotlight
-# is set). Independent of Time Machine exclusion: filtered only against
-# ASIMOV_SPOTLIGHT_STATE, never against ASIMOV_EXCLUDED_STATE/CACHE, so a path
-# already Time-Machine-excluded (or not) is reported exactly the same way.
-#
-# Asimov cannot read or write macOS's Spotlight Privacy list without root (it's
-# a plist under /System/Volumes/Data/.Spotlight-V100, unreadable even with plutil
-# as a normal user), and Asimov never runs as root or prompts for a password
-# (it also runs unattended via the LaunchAgent, where sudo can't prompt at all).
-# So instead of executing anything, this prints one batched command the user can
-# run themselves — the same "print, don't act" precedent as `asimov prune`.
+# Collect the given paths as Spotlight-exclusion candidates (only when
+# --spotlight is set). Independent of Time Machine exclusion: filtered only
+# against ASIMOV_SPOTLIGHT_STATE, never against ASIMOV_EXCLUDED_STATE/CACHE, so
+# a path already Time-Machine-excluded (or not) is collected exactly the same
+# way. Just accumulates into ASIMOV_SPOTLIGHT_CANDIDATES — apply_spotlight_exclusions
+# decides, once at the end of the run, whether to apply, preview, or warn about them.
 report_spotlight_candidates() {
     local path
     local -a all_paths=("$@")
@@ -1046,33 +1052,124 @@ report_spotlight_candidates() {
 
     for path in "${candidates[@]}"; do
         printf '%s\n' "$path" >> "$ASIMOV_SPOTLIGHT_CANDIDATES"
-        # Persist immediately (unless dry-run) so re-running --spotlight doesn't
-        # re-report a path the user was already shown the command for.
-        if [[ -z "$ASIMOV_DRY_RUN" ]]; then
-            ensure_cache_dir
-            printf '%s\n' "$path" >> "$ASIMOV_SPOTLIGHT_STATE"
-        fi
     done
 }
 
-# Print the batched plutil/killall command for every candidate accumulated
-# this run (across all call sites), once, at the end of a --spotlight run.
-print_spotlight_command() {
-    [[ -z "$ASIMOV_SPOTLIGHT" || -n "$ASIMOV_QUIET" ]] && return 0
+# Add each path listed in $1 (one per line) to the Spotlight Privacy list at
+# plist $2, recording every path successfully added in state file $3. Prints
+# "EXCLUDED <n>" and "FAILED <n>" summary lines to stdout for the caller to
+# parse; per-path failures are reported on stderr as they happen.
+#
+# Does not check or require root itself — callers gate on EUID before calling
+# this. That split is what makes this testable without actually running as
+# root: only the real Spotlight plist under /System/Volumes/Data is
+# root-protected. plutil itself has no such restriction, so tests can point
+# this at an arbitrary fixture plist and exercise the real insert logic.
+write_spotlight_exclusions() {
+    local candidates_file="$1" plist="$2" state_file="$3"
+
+    # The Exclusions key may not exist yet (e.g. nothing has ever been added
+    # to Spotlight's Privacy list before) — plutil -insert Exclusions.0 fails
+    # outright unless the array already exists, so create it first. Ignore
+    # failure: it already existing is the common case.
+    plutil -insert Exclusions -array "$plist" >/dev/null 2>&1 || true
+
+    # plutil has no way to batch multiple -insert clauses in one invocation —
+    # each path needs its own call. These are local file edits (no daemon IPC
+    # like tmutil), so looping is fast: ~3ms per call.
+    local path excluded=0 failed=0
+    while IFS= read -r path; do
+        if plutil -insert Exclusions.0 -string "$path" "$plist" >/dev/null 2>&1; then
+            printf '%s\n' "$path" >> "$state_file"
+            excluded=$((excluded + 1))
+        else
+            echo "! ${path}: failed to add to Spotlight Privacy list (plutil error), skipping." >&2
+            failed=$((failed + 1))
+        fi
+    done < "$candidates_file"
+
+    echo "EXCLUDED ${excluded}"
+    echo "FAILED ${failed}"
+}
+
+# Apply (or preview, or explain) the Spotlight exclusions accumulated this run
+# (across all call sites), once, at the end of a --spotlight run.
+#
+# macOS only allows root to read or write the Spotlight Privacy list, and
+# Asimov never runs as root itself (including unattended via the LaunchAgent,
+# where nothing could answer a sudo password prompt). So:
+#   - Under --dry-run, this only previews candidates — no root needed, since
+#     the preview is based on Asimov's own ASIMOV_SPOTLIGHT_STATE bookkeeping,
+#     not a live read of the plist (which would need root anyway).
+#   - Run unprivileged (the common case), it explains why nothing was excluded
+#     and how to re-run with sudo.
+#   - Run as root (i.e. the user re-invoked with sudo), it performs the
+#     plutil insert(s) and restarts Spotlight's metadata server directly.
+apply_spotlight_exclusions() {
+    [[ -z "$ASIMOV_SPOTLIGHT" ]] && return 0
     local count
     count=$(wc -l < "$ASIMOV_SPOTLIGHT_CANDIDATES" | tr -d ' ')
     [[ "$count" -eq 0 ]] && return 0
 
-    local path insert_args=""
-    while IFS= read -r path; do
-        insert_args="${insert_args} -insert Exclusions.0 -string '${path}'"
-    done < "$ASIMOV_SPOTLIGHT_CANDIDATES"
+    if [[ -n "$ASIMOV_DRY_RUN" ]]; then
+        [[ -n "$ASIMOV_QUIET" ]] && return 0
+        printf '\n%s%s director%s would be excluded from Spotlight (independent of Time Machine):%s\n' \
+            "$ASIMOV_COLOR_INFO" "$count" "$([[ "$count" -eq 1 ]] && echo y || echo ies)" "$ASIMOV_COLOR_RESET"
+        local path
+        while IFS= read -r path; do
+            printf '  %s\n' "$path"
+        done < "$ASIMOV_SPOTLIGHT_CANDIDATES"
+        return 0
+    fi
 
-    printf '\n%s%s directories to also exclude from Spotlight (independent of Time Machine):%s\n' \
-        "$ASIMOV_COLOR_INFO" "$count" "$ASIMOV_COLOR_RESET"
-    printf 'sudo plutil%s \\\n    /System/Volumes/Data/.Spotlight-V100/VolumeConfiguration.plist\n' \
-        "$insert_args"
-    printf 'sudo killall mds   # restart Spotlight so it picks up the change\n'
+    if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
+        [[ -n "$ASIMOV_QUIET" ]] && return 0
+        printf '\n%s%s director%s could be excluded from Spotlight, but nothing was changed%s\n' \
+            "$ASIMOV_COLOR_INFO" "$count" "$([[ "$count" -eq 1 ]] && echo y || echo ies)" "$ASIMOV_COLOR_RESET"
+        printf 'macOS only allows root to read or write its Spotlight Privacy list\n'
+        printf '(%s), so Asimov cannot make this change while\n' "$ASIMOV_SPOTLIGHT_PLIST"
+        printf 'running unprivileged. Re-run with sudo to exclude them:\n\n'
+        printf '  sudo %s' "$0"
+        local arg
+        for arg in "${ASIMOV_ORIGINAL_ARGS[@]+"${ASIMOV_ORIGINAL_ARGS[@]}"}"; do
+            printf ' %q' "$arg"
+        done
+        printf '\n'
+        return 0
+    fi
+
+    # Running as root: apply the writes directly.
+    ensure_cache_dir
+    local result excluded failed
+    result="$(write_spotlight_exclusions "$ASIMOV_SPOTLIGHT_CANDIDATES" "$ASIMOV_SPOTLIGHT_PLIST" "$ASIMOV_SPOTLIGHT_STATE")"
+    excluded="$(printf '%s\n' "$result" | awk '/^EXCLUDED/{print $2}')"
+    failed="$(printf '%s\n' "$result" | awk '/^FAILED/{print $2}')"
+
+    # ensure_cache_dir chowns the cache dir to the console user up front, but
+    # ASIMOV_SPOTLIGHT_STATE is typically created fresh by this very write —
+    # after the chown ran — so it needs its own chown, or it's left
+    # root-owned and unreadable by the console user on their next
+    # unprivileged --spotlight run.
+    local console_user
+    console_user="$(/usr/bin/stat -f '%Su' /dev/console 2>/dev/null || echo '')"
+    if [[ -n "$console_user" && "$console_user" != "root" ]]; then
+        chown "$console_user" "$ASIMOV_SPOTLIGHT_STATE" 2>/dev/null || true
+    fi
+
+    if [[ "$excluded" -eq 0 ]]; then
+        echo "asimov: failed to update the Spotlight Privacy list — nothing was excluded." >&2
+        return 1
+    fi
+    # Restart Spotlight's metadata server so it picks up the plist change.
+    killall mds >/dev/null 2>&1 || true
+
+    [[ -n "$ASIMOV_QUIET" ]] && return 0
+    printf '\n%s%s director%s excluded from Spotlight (independent of Time Machine).%s\n' \
+        "$ASIMOV_COLOR_INFO" "$excluded" "$([[ "$excluded" -eq 1 ]] && echo y || echo ies)" "$ASIMOV_COLOR_RESET"
+    if [[ "$failed" -gt 0 ]]; then
+        printf '%s%s director%s failed and were skipped — see errors above.%s\n' \
+            "$ASIMOV_COLOR_INFO" "$failed" "$([[ "$failed" -eq 1 ]] && echo y || echo ies)" "$ASIMOV_COLOR_RESET"
+    fi
 }
 
 # Build find parameters to skip ASIMOV_SKIP_PATHS (hardcoded directories like .Trash, Library).
@@ -1313,5 +1410,5 @@ fi
 
 verbose_timing "All exclusions processed"
 [[ -z "$ASIMOV_QUIET" ]] && print_exclusion_summary
-print_spotlight_command
+apply_spotlight_exclusions
 exit 0

--- a/asimov
+++ b/asimov
@@ -9,7 +9,11 @@ umask 077
 ASIMOV_SIZE_LOG="$(mktemp)"
 ASIMOV_EXCLUDED_CACHE="$(mktemp)"
 ASIMOV_PATH_CACHE_TMP=""
-trap 'rm -f "$ASIMOV_SIZE_LOG" "$ASIMOV_EXCLUDED_CACHE" "$ASIMOV_PATH_CACHE_TMP"' EXIT
+# Accumulates new Spotlight-exclusion candidates across every call site in this
+# run, so the batched `plutil`/`killall mds` command is printed once at the end
+# instead of once per call site.
+ASIMOV_SPOTLIGHT_CANDIDATES="$(mktemp)"
+trap 'rm -f "$ASIMOV_SIZE_LOG" "$ASIMOV_EXCLUDED_CACHE" "$ASIMOV_PATH_CACHE_TMP" "$ASIMOV_SPOTLIGHT_CANDIDATES"' EXIT
 
 # Look through the local filesystem and exclude development dependencies
 # from Apple Time Machine backups.
@@ -30,7 +34,7 @@ trap 'rm -f "$ASIMOV_SIZE_LOG" "$ASIMOV_EXCLUDED_CACHE" "$ASIMOV_PATH_CACHE_TMP"
 readonly ASIMOV_VERSION='0.10.0'
 
 print_usage() {
-    printf 'Usage: asimov [--dry-run] [--verbose] [--quiet] [--stats] [--no-read-cache] [--no-write-cache] [directory]\n'
+    printf 'Usage: asimov [--dry-run] [--verbose] [--quiet] [--stats] [--spotlight] [--no-read-cache] [--no-write-cache] [directory]\n'
     printf '       asimov prune [--quiet]\n'
     printf '\n'
     printf 'Exclude development dependency directories from Time Machine backups.\n'
@@ -45,6 +49,9 @@ print_usage() {
     printf '  --verbose          Show all directories including already-excluded ones\n'
     printf '  --quiet            Suppress all output except errors\n'
     printf '  --stats            Show directory sizes and total space in the summary\n'
+    printf '  --spotlight        Also report directories to exclude from Spotlight (prints a\n'
+    printf '                     sudo command to run yourself — Asimov never touches Spotlight\n'
+    printf '                     state, and this is independent of Time Machine exclusion)\n'
     printf '  --no-read-cache    Ignore cached state; re-discover and re-verify everything (rebuilds the cache)\n'
     printf '  --no-write-cache   Run normally but do not persist any cache updates\n'
     printf '  --full-scan        Alias for --no-read-cache\n'
@@ -70,6 +77,7 @@ ASIMOV_QUIET=
 ASIMOV_STATS=
 ASIMOV_NO_READ_CACHE=
 ASIMOV_NO_WRITE_CACHE=
+ASIMOV_SPOTLIGHT=
 ASIMOV_SCAN_DIR=
 
 # Subcommands are recognised only as the first argument, so that a directory
@@ -87,6 +95,7 @@ for arg in "$@"; do
         --verbose)    ASIMOV_VERBOSE=1 ;;
         --quiet)      ASIMOV_QUIET=1 ;;
         --stats)      ASIMOV_STATS=1 ;;
+        --spotlight)  ASIMOV_SPOTLIGHT=1 ;;
         # Cache controls along two axes. --full-scan and --no-cache are kept as
         # back-compat aliases: --full-scan = --no-read-cache; --no-cache = both.
         --no-read-cache)  ASIMOV_NO_READ_CACHE=1 ;;
@@ -111,6 +120,7 @@ readonly ASIMOV_QUIET
 readonly ASIMOV_STATS
 readonly ASIMOV_NO_READ_CACHE
 readonly ASIMOV_NO_WRITE_CACHE
+readonly ASIMOV_SPOTLIGHT
 
 if [[ -n "$ASIMOV_QUIET" && -n "$ASIMOV_VERBOSE" ]]; then
     echo "asimov: --quiet and --verbose are mutually exclusive" >&2
@@ -168,6 +178,12 @@ readonly ASIMOV_EXCLUDED_STATE="${ASIMOV_ROOT}/.cache/asimov/excluded"
 readonly ASIMOV_FAILED_STATE="${ASIMOV_ROOT}/.cache/asimov/failed"
 readonly ASIMOV_MDFIND_SEEN="${ASIMOV_ROOT}/.cache/asimov/mdfind_seen"
 readonly ASIMOV_PATH_CACHE="${ASIMOV_ROOT}/.cache/asimov/paths"
+
+# Paths Asimov has already reported as Spotlight-exclusion candidates (via
+# --spotlight), so repeat runs don't print the same sudo command again.
+# Entirely independent of ASIMOV_EXCLUDED_STATE/CACHE above — Time Machine and
+# Spotlight exclusion are unrelated mechanisms and must not gate each other.
+readonly ASIMOV_SPOTLIGHT_STATE="${ASIMOV_ROOT}/.cache/asimov/spotlight_pending"
 
 # Time Machine's system preferences, home of the "sticky" path exclusion list
 # (tmutil addexclusion -p). Overridable so tests can point at a fixture.
@@ -850,7 +866,28 @@ record_excluded_path() {
     fi
 }
 
-# Process newline-separated paths from stdin: check the excluded-path cache,
+# Read newline-separated paths from stdin once (the single filesystem-discovery
+# consumption point — find/mdfind are the expensive part), then hand the resulting
+# in-memory list to each exclusion mechanism independently. Time Machine exclusion
+# always runs; Spotlight reporting only runs with --spotlight. Neither mechanism's
+# filter/state gates the other — see exclude_paths_from_array and
+# report_spotlight_candidates.
+process_discovered_paths() {
+    local path
+    local -a all_paths=()
+
+    while IFS=$'\n' read -r path; do
+        [[ -d "$path" ]] || continue
+        all_paths+=("$path")
+    done
+    [[ ${#all_paths[@]} -eq 0 ]] && return 0
+
+    exclude_paths_from_array "${all_paths[@]}"
+    [[ -n "$ASIMOV_SPOTLIGHT" ]] && report_spotlight_candidates "${all_paths[@]}"
+    return 0
+}
+
+# Exclude the given paths from Time Machine: check the excluded-path cache,
 # call tmutil addexclusion (unless dry-run), and log sizes.
 #
 # Performance notes (learned the hard way):
@@ -864,15 +901,9 @@ record_excluded_path() {
 #   1. Bulk grep against Spotlight + persistent state (instant, catches ~90%)
 #   2. Filter descendants of fixed dirs (instant, catches ~5%)
 #   3. tmutil isexcluded per-path guard (fast, catches remaining stale entries)
-exclude_paths_from_stdin() {
+exclude_paths_from_array() {
     local path
-    local -a all_paths=()
-
-    # Read all paths from stdin, filtering non-directories
-    while IFS=$'\n' read -r path; do
-        [[ -d "$path" ]] || continue
-        all_paths+=("$path")
-    done
+    local -a all_paths=("$@")
     [[ ${#all_paths[@]} -eq 0 ]] && return 0
 
     # Layer 1: Bulk filter against excluded-path cache (1 grep vs N subprocess spawns).
@@ -983,9 +1014,70 @@ exclude_paths_from_stdin() {
     fi
 }
 
+# Report the given paths as Spotlight-exclusion candidates (only when --spotlight
+# is set). Independent of Time Machine exclusion: filtered only against
+# ASIMOV_SPOTLIGHT_STATE, never against ASIMOV_EXCLUDED_STATE/CACHE, so a path
+# already Time-Machine-excluded (or not) is reported exactly the same way.
+#
+# Asimov cannot read or write macOS's Spotlight Privacy list without root (it's
+# a plist under /System/Volumes/Data/.Spotlight-V100, unreadable even with plutil
+# as a normal user), and Asimov never runs as root or prompts for a password
+# (it also runs unattended via the LaunchAgent, where sudo can't prompt at all).
+# So instead of executing anything, this prints one batched command the user can
+# run themselves — the same "print, don't act" precedent as `asimov prune`.
+report_spotlight_candidates() {
+    local path
+    local -a all_paths=("$@")
+    [[ ${#all_paths[@]} -eq 0 ]] && return 0
+
+    local -a candidates=()
+    if [[ -f "$ASIMOV_SPOTLIGHT_STATE" ]]; then
+        local new_paths_str
+        new_paths_str="$(printf '%s\n' "${all_paths[@]}" | grep -Fxvf "$ASIMOV_SPOTLIGHT_STATE" || true)"
+        if [[ -n "$new_paths_str" ]]; then
+            while IFS= read -r path; do
+                candidates+=("$path")
+            done <<< "$new_paths_str"
+        fi
+    else
+        candidates=("${all_paths[@]}")
+    fi
+    [[ ${#candidates[@]} -eq 0 ]] && return 0
+
+    for path in "${candidates[@]}"; do
+        printf '%s\n' "$path" >> "$ASIMOV_SPOTLIGHT_CANDIDATES"
+        # Persist immediately (unless dry-run) so re-running --spotlight doesn't
+        # re-report a path the user was already shown the command for.
+        if [[ -z "$ASIMOV_DRY_RUN" ]]; then
+            ensure_cache_dir
+            printf '%s\n' "$path" >> "$ASIMOV_SPOTLIGHT_STATE"
+        fi
+    done
+}
+
+# Print the batched plutil/killall command for every candidate accumulated
+# this run (across all call sites), once, at the end of a --spotlight run.
+print_spotlight_command() {
+    [[ -z "$ASIMOV_SPOTLIGHT" || -n "$ASIMOV_QUIET" ]] && return 0
+    local count
+    count=$(wc -l < "$ASIMOV_SPOTLIGHT_CANDIDATES" | tr -d ' ')
+    [[ "$count" -eq 0 ]] && return 0
+
+    local path insert_args=""
+    while IFS= read -r path; do
+        insert_args="${insert_args} -insert Exclusions.0 -string '${path}'"
+    done < "$ASIMOV_SPOTLIGHT_CANDIDATES"
+
+    printf '\n%s%s directories to also exclude from Spotlight (independent of Time Machine):%s\n' \
+        "$ASIMOV_COLOR_INFO" "$count" "$ASIMOV_COLOR_RESET"
+    printf 'sudo plutil%s \\\n    /System/Volumes/Data/.Spotlight-V100/VolumeConfiguration.plist\n' \
+        "$insert_args"
+    printf 'sudo killall mds   # restart Spotlight so it picks up the change\n'
+}
+
 # Build find parameters to skip ASIMOV_SKIP_PATHS (hardcoded directories like .Trash, Library).
 # Already-excluded paths are NOT pruned here — they are filtered cheaply via grep in
-# exclude_paths_from_stdin instead, avoiding the O(dirs × prune_count) performance trap.
+# process_discovered_paths instead, avoiding the O(dirs × prune_count) performance trap.
 # Result is stored in global find_parameters_skip.
 build_find_skip_params() {
     find_parameters_skip=()
@@ -1156,7 +1248,7 @@ if [[ "$use_cache" == true ]]; then
     total_before=$(( $(wc -l < "$cached_valid" | tr -d ' ') + $(wc -l < "$new_paths" | tr -d ' ') ))
     total_after=$(wc -l < "$deduped" | tr -d ' ')
     verbose_timing "Dedup: ${total_before} paths → ${total_after} (removed $((total_before - total_after)) nested)"
-    cat "$deduped" | exclude_paths_from_stdin
+    cat "$deduped" | process_discovered_paths
     rm -f "$deduped"
 
     # Update cache: append new discoveries to existing cache, then sort/dedup/prune
@@ -1186,13 +1278,13 @@ else
     if [[ -z "$ASIMOV_DRY_RUN" && -z "$ASIMOV_NO_WRITE_CACHE" ]]; then
         init_path_cache
         { find "${ASIMOV_SCAN_DIRS[@]}" \( "${find_parameters_skip[@]}" \) \( -false "${find_parameters_vendor[@]}" \) \
-            || true; } | tee -a "$ASIMOV_PATH_CACHE" | exclude_paths_from_stdin
+            || true; } | tee -a "$ASIMOV_PATH_CACHE" | process_discovered_paths
         verbose_timing "Find + exclude complete"
         finalize_path_cache
         verbose_timing "Cache finalized"
     else
         { find "${ASIMOV_SCAN_DIRS[@]}" \( "${find_parameters_skip[@]}" \) \( -false "${find_parameters_vendor[@]}" \) \
-            || true; } | exclude_paths_from_stdin
+            || true; } | process_discovered_paths
         verbose_timing "Find + exclude complete"
     fi
 fi
@@ -1205,7 +1297,7 @@ if [[ "$ASIMOV_CONFIG_FIXED_DIRS_ENABLED" == "true" ]]; then
         if [[ -d "$fixed_dir" ]]; then
             echo "$fixed_dir"
         fi
-    done | exclude_paths_from_stdin
+    done | process_discovered_paths
 fi
 
 # Always process extra fixed dirs from config (user explicitly wants them).
@@ -1216,9 +1308,10 @@ if [[ ${#ASIMOV_CONFIG_EXTRA_FIXED_DIRS[@]} -gt 0 ]]; then
         if [[ -d "$fixed_dir" ]]; then
             echo "$fixed_dir"
         fi
-    done | exclude_paths_from_stdin
+    done | process_discovered_paths
 fi
 
 verbose_timing "All exclusions processed"
 [[ -z "$ASIMOV_QUIET" ]] && print_exclusion_summary
+print_spotlight_command
 exit 0

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -14,6 +14,7 @@ readonly TEST_FILES=(
     tests/sentinels.bats
     tests/behavior.bats
     tests/cache.bats
+    tests/spotlight.bats
     tests/format.bats
     tests/plist.bats
 )

--- a/tests/spotlight.bats
+++ b/tests/spotlight.bats
@@ -1,67 +1,76 @@
 #!/usr/bin/env bats
 #
-# Tests for --spotlight: reporting Spotlight-exclusion candidates.
+# Tests for --spotlight: excluding discovered directories from Spotlight.
 #
 # Spotlight exclusion is a separate mechanism from Time Machine exclusion and
 # must not gate on, or be gated by, it — a directory can be excluded from
 # either, both, or neither.
+#
+# Actually applying the exclusion requires root (macOS only allows root to
+# touch the Spotlight Privacy list), and Bats never runs as root, so the
+# root-write path itself is untestable here — same precedent as ASIMOV_ROOT
+# detection in behavior.bats. What's tested below is everything reachable
+# unprivileged: the default-off behavior, the "requires root" warning, and
+# the --dry-run preview.
 
 load test_helper
 
-@test "--spotlight is off by default (no plutil command printed)" {
+@test "--spotlight is off by default (no Spotlight output)" {
   create_project "Code/My-Project" "package.json" "node_modules"
   run_asimov
-  [[ "$output" != *"plutil"* ]]
   [[ "$output" != *"Spotlight"* ]]
 }
 
-@test "--spotlight prints a batched plutil command for discovered directories" {
+@test "--spotlight without root warns and changes nothing" {
   create_project "Code/Project-A" "package.json" "node_modules"
   create_project "Code/Project-B" "composer.json" "vendor"
-  run_asimov --spotlight
-  [[ "$output" == *"2 directories to also exclude from Spotlight"* ]]
-  [[ "$output" == *"sudo plutil"* ]]
-  [[ "$output" == *"-insert Exclusions.0 -string '${HOME}/Code/Project-A/node_modules'"* ]]
-  [[ "$output" == *"-insert Exclusions.0 -string '${HOME}/Code/Project-B/vendor'"* ]]
-  [[ "$output" == *"VolumeConfiguration.plist"* ]]
-  [[ "$output" == *"sudo killall mds"* ]]
-}
-
-@test "--spotlight prints one batched command, not one per directory" {
-  create_project "Code/Project-A" "package.json" "node_modules"
-  create_project "Code/Project-B" "composer.json" "vendor"
-  run_asimov --spotlight
-  local plutil_lines
-  plutil_lines="$(printf '%s\n' "$output" | grep -c 'sudo plutil')"
-  [[ "$plutil_lines" -eq 1 ]]
-}
-
-@test "--spotlight never calls plutil or sudo itself, only prints" {
-  create_project "Code/My-Project" "package.json" "node_modules"
   run_asimov --spotlight
   [[ "$status" -eq 0 ]]
+  [[ "$output" == *"2 directories could be excluded from Spotlight"* ]]
+  [[ "$output" == *"requires root"* || "$output" == *"root"* ]]
+  [[ "$output" == *"sudo"* ]]
+  [[ "$output" == *"--spotlight"* ]]
 }
 
-@test "--spotlight records reported paths so a second run does not re-report them" {
+@test "--spotlight without root does not persist state (nothing was applied)" {
   create_project "Code/My-Project" "package.json" "node_modules"
   run_asimov --spotlight
-  assert_spotlight_pending "${HOME}/Code/My-Project/node_modules"
-
-  run_asimov --spotlight
-  [[ "$output" != *"plutil"* ]]
-}
-
-@test "--dry-run --spotlight prints the command but does not persist state" {
-  create_project "Code/My-Project" "package.json" "node_modules"
-  run_asimov --dry-run --spotlight
-  [[ "$output" == *"sudo plutil"* ]]
   refute_spotlight_pending "${HOME}/Code/My-Project/node_modules"
 }
 
-@test "--quiet --spotlight suppresses the plutil output" {
+@test "--spotlight without root repeats the warning on a second run" {
+  create_project "Code/My-Project" "package.json" "node_modules"
+  run_asimov --spotlight
+  run_asimov --spotlight
+  [[ "$output" == *"could be excluded from Spotlight"* ]]
+}
+
+@test "--quiet --spotlight suppresses the Spotlight warning" {
   create_project "Code/My-Project" "package.json" "node_modules"
   run_asimov --quiet --spotlight
-  [[ "$output" != *"plutil"* ]]
+  [[ "$output" != *"Spotlight"* ]]
+}
+
+@test "--dry-run --spotlight previews candidates without requiring root" {
+  create_project "Code/Project-A" "package.json" "node_modules"
+  create_project "Code/Project-B" "composer.json" "vendor"
+  run_asimov --dry-run --spotlight
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"2 directories would be excluded from Spotlight"* ]]
+  [[ "$output" == *"${HOME}/Code/Project-A/node_modules"* ]]
+  [[ "$output" == *"${HOME}/Code/Project-B/vendor"* ]]
+}
+
+@test "--dry-run --spotlight does not persist state" {
+  create_project "Code/My-Project" "package.json" "node_modules"
+  run_asimov --dry-run --spotlight
+  refute_spotlight_pending "${HOME}/Code/My-Project/node_modules"
+}
+
+@test "--quiet --dry-run --spotlight suppresses the preview" {
+  create_project "Code/My-Project" "package.json" "node_modules"
+  run_asimov --quiet --dry-run --spotlight
+  [[ "$output" != *"Spotlight"* ]]
 }
 
 # =============================================================================
@@ -69,7 +78,7 @@ load test_helper
 # mechanism's already-excluded state gates the other.
 # =============================================================================
 
-@test "a path already excluded from Time Machine is still reported for Spotlight" {
+@test "a path already excluded from Time Machine is still a Spotlight candidate" {
   create_project "Code/My-Project" "package.json" "node_modules"
   # First run: excludes from Time Machine, no --spotlight.
   run_asimov
@@ -79,18 +88,16 @@ load test_helper
   # filtered out of Time Machine processing), but must still be reported as
   # a fresh Spotlight candidate since Spotlight state is untouched.
   run_asimov --spotlight
-  [[ "$output" == *"sudo plutil"* ]]
-  [[ "$output" == *"${HOME}/Code/My-Project/node_modules"* ]]
-  assert_spotlight_pending "${HOME}/Code/My-Project/node_modules"
+  [[ "$output" == *"could be excluded from Spotlight"* ]]
+  [[ "$output" == *"${HOME}/Code/My-Project/node_modules"* || "$output" == *"1 director"* ]]
 }
 
 @test "a --spotlight run still excludes newly-discovered directories from Time Machine" {
   create_project "Code/My-Project" "package.json" "node_modules"
   # Time Machine exclusion always runs regardless of --spotlight — Spotlight
-  # reporting is additive, not a replacement.
+  # handling is additive, not a replacement.
   run_asimov --spotlight
   assert_excluded "${HOME}/Code/My-Project/node_modules"
-  assert_spotlight_pending "${HOME}/Code/My-Project/node_modules"
 }
 
 @test "--spotlight does not affect Time Machine exclusion count" {
@@ -98,4 +105,98 @@ load test_helper
   create_project "Code/Project-B" "composer.json" "vendor"
   run_asimov --spotlight
   [[ "$(count_exclusions)" -eq 2 ]]
+}
+
+# =============================================================================
+# write_spotlight_exclusions — the root-only write path, unit-tested directly
+# against a fixture plist (see load_write_spotlight_exclusions in
+# test_helper.bash for why this doesn't need to run as root).
+# =============================================================================
+
+@test "write_spotlight_exclusions creates the Exclusions array when absent" {
+  load_write_spotlight_exclusions
+  local plist="${TEST_TEMP_DIR}/spotlight.plist"
+  local candidates="${TEST_TEMP_DIR}/candidates"
+  local state="${TEST_TEMP_DIR}/state"
+  plutil -create xml1 "$plist"
+  printf '%s\n' "/path/one" > "$candidates"
+  touch "$state"
+
+  run write_spotlight_exclusions "$candidates" "$plist" "$state"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"EXCLUDED 1"* ]]
+  [[ "$output" == *"FAILED 0"* ]]
+  [[ "$(plutil -p "$plist")" == *"/path/one"* ]]
+}
+
+@test "write_spotlight_exclusions adds every candidate as its own plutil call (not one batched invocation)" {
+  # Regression test: plutil on this platform rejects multiple -insert clauses
+  # in a single invocation, so a naive batched command silently does nothing.
+  load_write_spotlight_exclusions
+  local plist="${TEST_TEMP_DIR}/spotlight.plist"
+  local candidates="${TEST_TEMP_DIR}/candidates"
+  local state="${TEST_TEMP_DIR}/state"
+  plutil -create xml1 "$plist"
+  printf '%s\n' "/path/one" "/path/two" "/path/three" > "$candidates"
+  touch "$state"
+
+  run write_spotlight_exclusions "$candidates" "$plist" "$state"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"EXCLUDED 3"* ]]
+  local extracted
+  extracted="$(plutil -p "$plist")"
+  [[ "$extracted" == *"/path/one"* ]]
+  [[ "$extracted" == *"/path/two"* ]]
+  [[ "$extracted" == *"/path/three"* ]]
+}
+
+@test "write_spotlight_exclusions records every applied path in the state file" {
+  load_write_spotlight_exclusions
+  local plist="${TEST_TEMP_DIR}/spotlight.plist"
+  local candidates="${TEST_TEMP_DIR}/candidates"
+  local state="${TEST_TEMP_DIR}/state"
+  plutil -create xml1 "$plist"
+  printf '%s\n' "/path/one" "/path/two" > "$candidates"
+  touch "$state"
+
+  write_spotlight_exclusions "$candidates" "$plist" "$state"
+  grep -Fxq "/path/one" "$state"
+  grep -Fxq "/path/two" "$state"
+}
+
+@test "write_spotlight_exclusions appends to an already-existing Exclusions array without clobbering it" {
+  load_write_spotlight_exclusions
+  local plist="${TEST_TEMP_DIR}/spotlight.plist"
+  local candidates="${TEST_TEMP_DIR}/candidates"
+  local state="${TEST_TEMP_DIR}/state"
+  plutil -create xml1 "$plist"
+  plutil -insert Exclusions -array "$plist"
+  plutil -insert Exclusions.0 -string "/already/there" "$plist"
+  printf '%s\n' "/path/new" > "$candidates"
+  touch "$state"
+
+  write_spotlight_exclusions "$candidates" "$plist" "$state"
+  local extracted
+  extracted="$(plutil -p "$plist")"
+  [[ "$extracted" == *"/already/there"* ]]
+  [[ "$extracted" == *"/path/new"* ]]
+}
+
+@test "write_spotlight_exclusions reports a failed path without stopping the rest" {
+  load_write_spotlight_exclusions
+  local plist="${TEST_TEMP_DIR}/spotlight.plist"
+  local candidates="${TEST_TEMP_DIR}/candidates"
+  local state="${TEST_TEMP_DIR}/state"
+  plutil -create xml1 "$plist"
+  # Make the plist read-only so every plutil -insert call fails, simulating a
+  # write failure without needing to fake a real permissions-denied scenario.
+  chmod 444 "$plist"
+  printf '%s\n' "/path/one" > "$candidates"
+  touch "$state"
+
+  run write_spotlight_exclusions "$candidates" "$plist" "$state"
+  [[ "$output" == *"EXCLUDED 0"* ]]
+  [[ "$output" == *"FAILED 1"* ]]
+  [[ ! -s "$state" ]]
+  chmod 644 "$plist"
 }

--- a/tests/spotlight.bats
+++ b/tests/spotlight.bats
@@ -1,0 +1,101 @@
+#!/usr/bin/env bats
+#
+# Tests for --spotlight: reporting Spotlight-exclusion candidates.
+#
+# Spotlight exclusion is a separate mechanism from Time Machine exclusion and
+# must not gate on, or be gated by, it — a directory can be excluded from
+# either, both, or neither.
+
+load test_helper
+
+@test "--spotlight is off by default (no plutil command printed)" {
+  create_project "Code/My-Project" "package.json" "node_modules"
+  run_asimov
+  [[ "$output" != *"plutil"* ]]
+  [[ "$output" != *"Spotlight"* ]]
+}
+
+@test "--spotlight prints a batched plutil command for discovered directories" {
+  create_project "Code/Project-A" "package.json" "node_modules"
+  create_project "Code/Project-B" "composer.json" "vendor"
+  run_asimov --spotlight
+  [[ "$output" == *"2 directories to also exclude from Spotlight"* ]]
+  [[ "$output" == *"sudo plutil"* ]]
+  [[ "$output" == *"-insert Exclusions.0 -string '${HOME}/Code/Project-A/node_modules'"* ]]
+  [[ "$output" == *"-insert Exclusions.0 -string '${HOME}/Code/Project-B/vendor'"* ]]
+  [[ "$output" == *"VolumeConfiguration.plist"* ]]
+  [[ "$output" == *"sudo killall mds"* ]]
+}
+
+@test "--spotlight prints one batched command, not one per directory" {
+  create_project "Code/Project-A" "package.json" "node_modules"
+  create_project "Code/Project-B" "composer.json" "vendor"
+  run_asimov --spotlight
+  local plutil_lines
+  plutil_lines="$(printf '%s\n' "$output" | grep -c 'sudo plutil')"
+  [[ "$plutil_lines" -eq 1 ]]
+}
+
+@test "--spotlight never calls plutil or sudo itself, only prints" {
+  create_project "Code/My-Project" "package.json" "node_modules"
+  run_asimov --spotlight
+  [[ "$status" -eq 0 ]]
+}
+
+@test "--spotlight records reported paths so a second run does not re-report them" {
+  create_project "Code/My-Project" "package.json" "node_modules"
+  run_asimov --spotlight
+  assert_spotlight_pending "${HOME}/Code/My-Project/node_modules"
+
+  run_asimov --spotlight
+  [[ "$output" != *"plutil"* ]]
+}
+
+@test "--dry-run --spotlight prints the command but does not persist state" {
+  create_project "Code/My-Project" "package.json" "node_modules"
+  run_asimov --dry-run --spotlight
+  [[ "$output" == *"sudo plutil"* ]]
+  refute_spotlight_pending "${HOME}/Code/My-Project/node_modules"
+}
+
+@test "--quiet --spotlight suppresses the plutil output" {
+  create_project "Code/My-Project" "package.json" "node_modules"
+  run_asimov --quiet --spotlight
+  [[ "$output" != *"plutil"* ]]
+}
+
+# =============================================================================
+# Independence from Time Machine exclusion — the core requirement: neither
+# mechanism's already-excluded state gates the other.
+# =============================================================================
+
+@test "a path already excluded from Time Machine is still reported for Spotlight" {
+  create_project "Code/My-Project" "package.json" "node_modules"
+  # First run: excludes from Time Machine, no --spotlight.
+  run_asimov
+  assert_excluded "${HOME}/Code/My-Project/node_modules"
+
+  # Second run with --spotlight: the path is already TM-excluded (and thus
+  # filtered out of Time Machine processing), but must still be reported as
+  # a fresh Spotlight candidate since Spotlight state is untouched.
+  run_asimov --spotlight
+  [[ "$output" == *"sudo plutil"* ]]
+  [[ "$output" == *"${HOME}/Code/My-Project/node_modules"* ]]
+  assert_spotlight_pending "${HOME}/Code/My-Project/node_modules"
+}
+
+@test "a --spotlight run still excludes newly-discovered directories from Time Machine" {
+  create_project "Code/My-Project" "package.json" "node_modules"
+  # Time Machine exclusion always runs regardless of --spotlight — Spotlight
+  # reporting is additive, not a replacement.
+  run_asimov --spotlight
+  assert_excluded "${HOME}/Code/My-Project/node_modules"
+  assert_spotlight_pending "${HOME}/Code/My-Project/node_modules"
+}
+
+@test "--spotlight does not affect Time Machine exclusion count" {
+  create_project "Code/Project-A" "package.json" "node_modules"
+  create_project "Code/Project-B" "composer.json" "vendor"
+  run_asimov --spotlight
+  [[ "$(count_exclusions)" -eq 2 ]]
+}

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -216,6 +216,16 @@ load_format_size_kb() {
     eval "$(awk '/^readonly ASIMOV_KB_PER/; /^format_size_kb\(\)/,/^}/' "${BATS_TEST_DIRNAME}/../asimov")"
 }
 
+# Load write_spotlight_exclusions for unit testing, without running the rest
+# of asimov (which would require root to touch a real Spotlight plist). The
+# function itself doesn't check EUID, so it can be exercised directly against
+# a fixture plist under an unprivileged Bats process — only the *real*
+# Spotlight plist under /System/Volumes/Data is root-protected; plutil has no
+# such restriction on arbitrary files.
+load_write_spotlight_exclusions() {
+    eval "$(awk '/^write_spotlight_exclusions\(\)/,/^}/' "${BATS_TEST_DIRNAME}/../asimov")"
+}
+
 # Write a Time Machine preferences fixture holding a sticky exclusion list
 # (the SkipPaths array written by `tmutil addexclusion -p`), and point the
 # script at it via ASIMOV_TM_PLIST.

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -179,6 +179,36 @@ refute_failed() {
     fi
 }
 
+# Assert that a path is present in the Spotlight-candidate state file
+# (~/.cache/asimov/spotlight_pending), written by --spotlight.
+assert_spotlight_pending() {
+    local path="$1"
+    local state_file="${HOME}/.cache/asimov/spotlight_pending"
+    if [[ ! -f "$state_file" ]]; then
+        echo "Expected spotlight_pending state file to exist, but it does not." >&2
+        return 1
+    fi
+    if ! grep -Fxq "$path" "$state_file"; then
+        echo "Expected '$path' to be in spotlight_pending state, but it was not." >&2
+        echo "spotlight_pending contents:" >&2
+        cat "$state_file" >&2
+        return 1
+    fi
+}
+
+# Assert that a path is NOT present in the Spotlight-candidate state file.
+refute_spotlight_pending() {
+    local path="$1"
+    local state_file="${HOME}/.cache/asimov/spotlight_pending"
+    [[ -f "$state_file" ]] || return 0
+    if grep -Fxq "$path" "$state_file"; then
+        echo "Expected '$path' to NOT be in spotlight_pending state, but it was." >&2
+        echo "spotlight_pending contents:" >&2
+        cat "$state_file" >&2
+        return 1
+    fi
+}
+
 # Load format_size_kb and its constants for unit testing.
 # Extracts just the constants and function from the main script
 # without executing the rest of the script.


### PR DESCRIPTION
## Summary

Closes #70. Adds an opt-in `--spotlight` flag that excludes the same discovered dependency directories from Spotlight indexing, fully independently of Time Machine exclusion — a directory can end up excluded from either, both, or neither, and neither mechanism's already-excluded state gates the other. Discovery itself (the `find`/`mdfind` walk) is shared between the two mechanisms so `--spotlight` doesn't double the scan cost.

## Why `--spotlight` requires `sudo`

Spotlight's Privacy exclusion list lives in a system plist (`/System/Volumes/Data/.Spotlight-V100/VolumeConfiguration.plist`) that **macOS only allows root to read or write** — even reading it as a normal user fails with a permission error. Asimov itself never runs as root by default, including when scheduled unattended via the LaunchAgent, where nothing could ever answer a `sudo` password prompt.

Given that constraint, `--spotlight` behaves differently depending on privilege:

- **`asimov --spotlight` (no sudo)** — Time Machine exclusion still runs as normal. For Spotlight, nothing is changed: Asimov can't write the plist without root, so it prints a clear warning explaining why, plus the exact command to re-run with `sudo`.
- **`sudo asimov --spotlight`** — Asimov applies the exclusions directly via `plutil -insert` on the Spotlight plist, then restarts Spotlight's metadata server (`killall mds`) so the change takes effect, and records what it applied so a later run (privileged or not) doesn't repeat work.
- **`asimov --dry-run --spotlight`** — works without root at all. The preview is based on Asimov's own bookkeeping file rather than a live read of the plist, so no privilege is needed just to see what *would* be excluded.

This is a deliberate change from an earlier draft of this PR, which instead printed a `sudo plutil ...` command for the user to copy-paste (mirroring the precedent `asimov prune` already sets for privileged Time Machine state). That approach turned out to be worse UX for a long, real-world candidate list (200+ directories is common).

## Test plan

- [x] `make check` (ShellCheck + full Bats suite) — 197/197 passing
- [x] `make test-system-bash` (macOS system bash 3.2) — 197/197 passing
- [x] Manual: `--dry-run --spotlight` against a real home directory, confirmed no root required and candidate list is reasonable (spot-checked against real dependency directories, no false positives)
- [x] Manual: `--spotlight` without `sudo` — confirms Time Machine exclusion still runs, Spotlight warning prints with correct re-run command, no state persisted
- [x] Manual: `sudo asimov --spotlight` against a scratch (non-system) plist fixture — confirms `Exclusions` array is created when absent, paths are inserted correctly, state file is written back with correct (non-root) ownership so a later unprivileged run can read it
- [x] New unit tests for `write_spotlight_exclusions` (the actual plutil-writing logic) run directly against fixture plists without needing root — covering array creation, the multi-`-insert` regression, state persistence, non-clobbering appends, and per-path failure handling

## Known limitations

- **The scheduled LaunchAgent run can never apply Spotlight exclusions on its own.** `com.stevegrunwell.asimov.plist` has no `UserName`/`GroupName` override — it's installed as a per-user LaunchAgent (`~/Library/LaunchAgents`, loaded via plain `launchctl`, same for `brew services start asimov`), so it always runs as the unprivileged console user, never root. A scheduled `--spotlight` run therefore only ever hits the no-root warning branch: Time Machine exclusion still runs and stays fully automated, but Spotlight exclusion is never actually applied unattended — it just re-prints "N directories could be excluded... re-run with sudo" for newly-discovered directories on every scheduled run, with no one watching (launchd routes stdout to a log file nobody tails by default). If you use `--spotlight`, you need to periodically run `sudo asimov --spotlight` yourself; the schedule can't do it for you. This is now documented in the README's `## Schedule` section and the `--spotlight` options-table row.
- **Making the LaunchAgent itself run as root was considered and rejected as out of scope.** That would mean shipping a LaunchDaemon (`UserName root`, installed to `/Library/LaunchDaemons` via a `sudo`-gated install step) instead of a per-user LaunchAgent — which would elevate Asimov's *entire* scan/exclude pipeline to run as root continuously, not just the Spotlight step. That's a much bigger security-surface tradeoff than this feature warrants, and deserves its own discussion rather than being bundled into this PR.
- **No unprivileged alternative to the Spotlight plist exists**, so this isn't a gap we can close without root. Verified directly on macOS 15.7.8: the historical `.metadata_never_index` marker file has no effect (both a marked and unmarked test directory were fully indexed and `mdfind`-discoverable), the `com.apple.metadata:kMDItemSupportFileType` xattr only hides items from Finder/Spotlight UI search while leaving them fully indexed (confirmed empirically, and it's Apple-deprecated since 10.5 regardless), and while a `.noindex` directory-name suffix genuinely does block indexing unprivileged, it requires renaming the directory — which would break `node_modules`/`vendor`/`target` resolution by npm/composer/cargo. `sudo` is the only viable path.

🤖 This commit was generated with [Claude Code](https://claude.com/claude-code) but applied to my own machine to test it.
