### PR TITLE
fix(cache): survive an unusable cache, and add asimov doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- `asimov doctor` checks an install rather than your projects: which `asimov` your shell
+  actually runs (and flags an older one shadowing it on `PATH`), whether a schedule is
+  installed and loaded, whether `~/.cache/asimov/` is readable and writable by you,
+  whether the config file parses, and whether `tmutil` can read exclusions at all. It is
+  read-only — it prints the fix rather than applying it — and never executes another
+  `asimov` binary it finds, reading versions out of the file instead, because v0.3.0
+  ignores every argument and would start a real scan. Exits `1` if it finds anything
+  ([#122](https://github.com/AsimovMac/asimov/issues/122)).
+- `UPGRADING.md`: a section for upgrading from v0.3.0, the version most people have,
+  covering the three leftovers that outlive it — the LaunchAgent, the old cellar, and a
+  root-owned cache — in an order that works
+  ([#122](https://github.com/AsimovMac/asimov/issues/122)).
+
 - `make test-system-bash` runs the suite under the macOS system bash (3.2), which is what
   most users get — `asimov` starts with `#!/usr/bin/env bash`, and a development machine
   usually has 5.x first on `PATH`. `make test BASH_BIN=<path>` pins any interpreter, and
@@ -34,6 +47,18 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   others, and a newer push cancels an in-flight run for the same ref.
 
 ### Fixed
+
+- An unreadable or unwritable file under `~/.cache/asimov/` no longer kills the run. The
+  cache is an optimisation, but a bare `cat` on an unreadable state file failed under
+  `set -Eeu -o pipefail` and aborted immediately, printing nothing but `Permission
+  denied`. Every cache read and write is now guarded: Asimov warns once, names the reset
+  command, and continues without the cache
+  ([#122](https://github.com/AsimovMac/asimov/issues/122)).
+- A run as root no longer leaves root-owned files behind that break the next run as your
+  own user — the cause of the failure above. The cache directory was chowned to the
+  console user, but the state files written afterwards were not; they are now created
+  before the chown, and appending never changes an existing file's owner
+  ([#122](https://github.com/AsimovMac/asimov/issues/122)).
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ If `mdfind` doesn't list your projects, the run isn't reaching them. The two usu
 
 ```
 asimov [--dry-run] [--verbose] [--quiet] [--stats] [--no-read-cache] [--no-write-cache] [--help] [--version]
+asimov prune  [--quiet]
+asimov doctor [--quiet]
 ```
 
 
@@ -179,6 +181,44 @@ Asimov keeps a cache under `~/.cache/asimov/` so repeat runs are near-instant. T
 - `--no-write-cache` — *"don't touch state."* Uses the fast cache to read, but persists nothing. Handy with `--dry-run`.
 - Both together = a fully stateless run that reads and writes nothing. **`--no-cache` is an alias for this.**
 
+
+### `asimov doctor`
+
+Checks the install itself rather than your projects. Run it when something seems off, or straight after an upgrade.
+
+```
+$ asimov doctor
+
+Asimov doctor
+
+Install
+  ✓ asimov 0.10.0 (/opt/homebrew/bin/asimov)
+  ✗ typing 'asimov' runs a different binary — this one is shadowed
+      /usr/local/bin/asimov  (version 0.3.0)
+      Remove the one you don't want, or fix the order of PATH.
+
+Schedule
+  ✗ homebrew.mxcl.asimov: its program /opt/homebrew/Cellar/asimov/0.3.0/bin/asimov no longer exists
+      launchctl bootout gui/$(id -u)/homebrew.mxcl.asimov
+      rm ~/Library/LaunchAgents/homebrew.mxcl.asimov.plist
+
+Cache
+  ✗ ~/.cache/asimov/excluded is not readable and writable by you (owner: root)
+      A run as root left these behind. Clear them:
+      rm -rf ~/.cache/asimov
+
+Config
+  ✓ ~/.config/asimov/config looks valid
+
+Time Machine
+  ✓ tmutil can read exclusions
+
+3 problems found.
+```
+
+It covers five things: which `asimov` your shell actually runs, whether a schedule is installed and loaded, whether the cache is readable and writable by you, whether the config parses, and whether `tmutil` can read exclusions at all (it can't without Full Disk Access).
+
+`doctor` is **read-only** — it prints the fix rather than applying it — and it never executes another `asimov` binary it finds, reading versions out of the file instead. It exits `1` if it finds anything, so it's safe to use in a script.
 
 ## Schedule
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,71 @@
 # Upgrading Asimov
 
+## To v0.10.0 from v0.3.0 (the original `stevegrunwell/asimov`)
+
+Most people upgrading are coming from `0.3.0`, the version Homebrew shipped for years.
+It upgrades cleanly, but three leftovers can outlive it. Work through this in order.
+
+**Before you start: don't run `asimov` to check your version.** v0.3.0 parses no
+arguments at all — it ignores `--version`, `--help`, and every subcommand, and goes
+straight to scanning and writing Time Machine exclusions. Read the version out of the
+file instead:
+
+```sh
+grep -m1 -E '@version|ASIMOV_VERSION=' "$(command -v asimov)"
+```
+
+### 1. Stop the schedule before you uninstall
+
+Uninstalling first leaves the LaunchAgent behind with nothing to run:
+
+```sh
+brew services stop asimov
+launchctl bootout gui/$(id -u)/homebrew.mxcl.asimov 2>/dev/null
+rm -f ~/Library/LaunchAgents/homebrew.mxcl.asimov.plist
+```
+
+### 2. Replace the binary
+
+```sh
+brew uninstall asimov
+brew install asimov
+```
+
+If `brew uninstall` reports `Permission denied @ apply2files`, the old cellar files are
+owned by another user — Homebrew prints the `sudo` command to force it, and that is safe
+here.
+
+### 3. Clear the old cache
+
+v0.10.0 keeps state in `~/.cache/asimov/`. If anything ever ran Asimov as root, those
+files are root-owned and unreadable by you:
+
+```sh
+rm -rf ~/.cache/asimov
+```
+
+v0.10.0 and earlier crashed outright on this with a bare `Permission denied`. Current
+versions warn and carry on, but clearing it is still the fix.
+
+### 4. Check the result
+
+`doctor` exists only in current versions, so it comes last — there is nothing to run
+before the new binary is in place:
+
+```sh
+asimov doctor
+```
+
+It reports a shadowed binary, a leftover schedule, an unreadable cache, and a bad config,
+and exits non-zero if it finds any. If it prints usage errors or starts a scan instead,
+an old binary is still first on your `PATH` — `doctor` names the one it found.
+
+### One thing that isn't broken
+
+Asimov is a one-shot scan, not a daemon. After `brew services start asimov`, `ps aux |
+grep asimov` finding nothing is expected: it scans, excludes, and exits. To confirm it is
+actually scheduled, use `asimov doctor`.
+
 ## To v0.10.0 (from the `django23/asimov` fork)
 
 `0.10.0` folds the fork's work (v0.4.0–v0.8.0, plus a `v0.9.0-beta` round) back into

--- a/asimov
+++ b/asimov
@@ -32,6 +32,7 @@ readonly ASIMOV_VERSION='0.10.0'
 print_usage() {
     printf 'Usage: asimov [--dry-run] [--verbose] [--quiet] [--stats] [--no-read-cache] [--no-write-cache] [directory]\n'
     printf '       asimov prune [--quiet]\n'
+    printf '       asimov doctor [--quiet]\n'
     printf '\n'
     printf 'Exclude development dependency directories from Time Machine backups.\n'
     printf '\n'
@@ -39,6 +40,9 @@ print_usage() {
     printf '  prune              Report Time Machine exclusions whose directory no longer\n'
     printf '                     exists, and compact Asimov'\''s own cache. Read-only:\n'
     printf '                     it prints the removal command rather than running it\n'
+    printf '  doctor             Check this install for problems: a shadowed binary, a\n'
+    printf '                     leftover schedule, an unreadable cache, a bad config.\n'
+    printf '                     Read-only; exits 1 if it finds anything\n'
     printf '\n'
     printf 'Options:\n'
     printf '  --dry-run          Print what would be excluded without changing Time Machine\n'
@@ -75,10 +79,10 @@ ASIMOV_SCAN_DIR=
 # Subcommands are recognised only as the first argument, so that a directory
 # sharing the name stays reachable as `asimov ./prune`.
 ASIMOV_COMMAND=scan
-if [[ "${1:-}" == "prune" ]]; then
-    ASIMOV_COMMAND=prune
-    shift
-fi
+case "${1:-}" in
+    prune)  ASIMOV_COMMAND=prune;  shift ;;
+    doctor) ASIMOV_COMMAND=doctor; shift ;;
+esac
 readonly ASIMOV_COMMAND
 
 for arg in "$@"; do
@@ -168,6 +172,60 @@ readonly ASIMOV_EXCLUDED_STATE="${ASIMOV_ROOT}/.cache/asimov/excluded"
 readonly ASIMOV_FAILED_STATE="${ASIMOV_ROOT}/.cache/asimov/failed"
 readonly ASIMOV_MDFIND_SEEN="${ASIMOV_ROOT}/.cache/asimov/mdfind_seen"
 readonly ASIMOV_PATH_CACHE="${ASIMOV_ROOT}/.cache/asimov/paths"
+readonly ASIMOV_CACHE_DIR="${ASIMOV_ROOT}/.cache/asimov"
+
+# --- cache resilience ---
+#
+# Every cache file is an optimisation: a run must survive one being unreadable
+# or unwritable rather than aborting. Without these guards a bare `cat` on an
+# unreadable state file fails under `set -Eeu -o pipefail` and kills the whole
+# run, printing nothing but "Permission denied" (see issue #122).
+#
+# The usual cause is a run as root — `sudo asimov`, or a schedule installed as
+# root — leaving root-owned files behind for the next run as the user.
+ASIMOV_CACHE_WARNED=
+
+# Warn once per run that the cache is unusable, and name the fix. Always goes to
+# stderr, including under --quiet: this is a degraded run, not routine chatter.
+warn_unusable_cache() {
+    [[ -n "$ASIMOV_CACHE_WARNED" ]] && return 0
+    ASIMOV_CACHE_WARNED=1
+    printf '! %s is not %s — continuing without the cache.\n' "$1" "$2" >&2
+    printf '  This usually means a previous run as root left root-owned files behind.\n' >&2
+    printf '  To reset it:\n\n    rm -rf %s\n\n' "$ASIMOV_CACHE_DIR" >&2
+    return 0
+}
+
+# True when a state file exists and can be read. A missing file is not an error
+# (there is simply nothing cached yet), so it returns false without warning.
+cache_readable() {
+    [[ -f "$1" ]] || return 1
+    [[ -r "$1" ]] && return 0
+    warn_unusable_cache "$1" "readable"
+    return 1
+}
+
+# True when a state file can be written to, creating it if necessary. An absent
+# file is writable when its directory is.
+cache_writable() {
+    if [[ -e "$1" ]]; then
+        [[ -w "$1" ]] && return 0
+        warn_unusable_cache "$1" "writable"
+        return 1
+    fi
+    [[ -d "$ASIMOV_CACHE_DIR" && -w "$ASIMOV_CACHE_DIR" ]] && return 0
+    [[ -d "$ASIMOV_CACHE_DIR" ]] || return 1   # not created yet; ensure_cache_dir reports
+    warn_unusable_cache "$ASIMOV_CACHE_DIR" "writable"
+    return 1
+}
+
+# Append a line to a state file, skipping silently when it isn't writable.
+# Always returns 0 so callers can use it as the tail of an && list under set -e.
+append_state() {
+    cache_writable "$2" || return 0
+    printf '%s\n' "$1" >> "$2" 2>/dev/null || true
+    return 0
+}
 
 # Time Machine's system preferences, home of the "sticky" path exclusion list
 # (tmutil addexclusion -p). Overridable so tests can point at a fixture.
@@ -221,7 +279,8 @@ read_sticky_exclusions() {
 # Echoes the number of entries removed. This only ever touches Asimov's own
 # file under ~/.cache/asimov.
 prune_path_cache() {
-    [[ -f "$ASIMOV_PATH_CACHE" ]] || { echo 0; return 0; }
+    cache_readable "$ASIMOV_PATH_CACHE" || { echo 0; return 0; }
+    cache_writable "$ASIMOV_PATH_CACHE" || { echo 0; return 0; }
 
     # A brace group with a redirect runs in the current shell, so the counters
     # below survive the loop.
@@ -296,6 +355,349 @@ cmd_prune() {
 if [[ "$ASIMOV_COMMAND" == "prune" ]]; then
     cmd_prune
     exit 0
+fi
+
+# --- doctor ---
+#
+# Diagnoses an install rather than changing it. The failure modes it looks for
+# are the ones people hit coming from v0.3.0 (issue #122): an old binary still
+# first on PATH, a LaunchAgent pointing at a Homebrew cellar that no longer
+# exists, and a cache left root-owned by a run as root.
+#
+# Two rules keep it safe to run at any point in a migration:
+#   - It never writes anything. Fixes are printed, never applied.
+#   - It never executes another asimov binary it finds. v0.3.0 parses no
+#     arguments at all, so running it to ask its version would start a real
+#     scan; versions are read out of the file instead.
+
+# The label a current install schedules itself under. Everything else in the
+# list below is a leftover to be removed, never re-loaded.
+readonly ASIMOV_CURRENT_LABEL='com.stevegrunwell.asimov'
+
+# Every known LaunchAgent label Asimov has ever shipped under, plus Homebrew's.
+readonly ASIMOV_DOCTOR_LABELS=(
+    'com.stevegrunwell.asimov'   # current, and the original
+    'com.django23.asimov'        # the v0.4.x–v0.8.0 fork
+    'homebrew.mxcl.asimov'       # brew services
+)
+
+ASIMOV_DOCTOR_PROBLEMS=0
+
+doctor_heading() {
+    [[ -n "$ASIMOV_QUIET" ]] && return 0
+    printf '\n%s%s%s\n' "$ASIMOV_COLOR_INFO" "$1" "$ASIMOV_COLOR_RESET"
+    return 0
+}
+
+doctor_ok() {
+    [[ -n "$ASIMOV_QUIET" ]] && return 0
+    printf '  %s✓%s %s\n' "$ASIMOV_COLOR_SUCCESS" "$ASIMOV_COLOR_RESET" "$1"
+    return 0
+}
+
+doctor_note() {
+    [[ -n "$ASIMOV_QUIET" ]] && return 0
+    printf '  %s·%s %s\n' "$ASIMOV_COLOR_DIM" "$ASIMOV_COLOR_RESET" "$1"
+    return 0
+}
+
+# Problems print even under --quiet: a silent doctor that found something is
+# worse than useless in a cron job.
+doctor_problem() {
+    ASIMOV_DOCTOR_PROBLEMS=$((ASIMOV_DOCTOR_PROBLEMS + 1))
+    printf '  ✗ %s\n' "$1"
+    return 0
+}
+
+# Print a command the user can copy to fix the problem just reported.
+doctor_fix() {
+    printf '      %s%s%s\n' "$ASIMOV_COLOR_DIM" "$1" "$ASIMOV_COLOR_RESET"
+    return 0
+}
+
+# Resolve a path to its physical location, symlinks and all. Homebrew installs
+# asimov as a symlink into the cellar, so comparing raw paths would report a
+# shadow that isn't there.
+doctor_realpath() {
+    local path="$1" dir base
+    dir="$(cd "$(dirname "$path")" 2>/dev/null && pwd -P)" || { printf '%s\n' "$path"; return 0; }
+    base="$(basename "$path")"
+    while [[ -L "${dir}/${base}" ]]; do
+        local target
+        target="$(readlink "${dir}/${base}")"
+        case "$target" in
+            /*) dir="$(cd "$(dirname "$target")" 2>/dev/null && pwd -P)" || break ;;
+            *)  dir="$(cd "$dir" && cd "$(dirname "$target")" 2>/dev/null && pwd -P)" || break ;;
+        esac
+        base="$(basename "$target")"
+    done
+    printf '%s/%s\n' "$dir" "$base"
+}
+
+# Read a version out of an asimov script without running it. Handles both the
+# current `readonly ASIMOV_VERSION='x'` and v0.3.0's `# @version x` header.
+doctor_file_version() {
+    local file="$1" line
+    line="$(grep -m1 -E "^readonly ASIMOV_VERSION=|^# @version " "$file" 2>/dev/null || true)"
+    [[ -n "$line" ]] || { printf 'unknown\n'; return 0; }
+    line="${line##*@version }"
+    line="${line##*=}"
+    line="${line//\'/}"
+    line="${line//\"/}"
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    printf '%s\n' "${line:-unknown}"
+}
+
+# Every `asimov` on PATH, in PATH order, deduplicated by physical path.
+doctor_path_binaries() {
+    local dir candidate resolved seen=""
+    while IFS= read -r dir; do
+        [[ -n "$dir" ]] || continue
+        candidate="${dir}/asimov"
+        [[ -x "$candidate" && ! -d "$candidate" ]] || continue
+        resolved="$(doctor_realpath "$candidate")"
+        case "$seen" in
+            *"|${resolved}|"*) continue ;;
+        esac
+        seen="${seen}|${resolved}|"
+        printf '%s\n' "$resolved"
+    done < <(printf '%s\n' "${PATH//:/$'\n'}")
+}
+
+doctor_check_install() {
+    doctor_heading 'Install'
+
+    local running
+    running="$(doctor_realpath "${BASH_SOURCE[0]}")"
+    doctor_ok "asimov ${ASIMOV_VERSION} (${running})"
+
+    local -a found=()
+    while IFS= read -r line; do
+        [[ -n "$line" ]] && found+=("$line")
+    done < <(doctor_path_binaries)
+
+    if [[ ${#found[@]} -eq 0 ]]; then
+        doctor_note "no asimov on PATH — you are running it by path"
+        return 0
+    fi
+
+    local first="${found[0]}"
+    if [[ "$first" != "$running" ]]; then
+        doctor_problem "typing 'asimov' runs a different binary — this one is shadowed"
+        doctor_fix "${first}  (version $(doctor_file_version "$first"))"
+        doctor_fix "Remove the one you don't want, or fix the order of PATH."
+    else
+        doctor_ok "'asimov' on PATH is this one"
+    fi
+
+    local other
+    for other in "${found[@]}"; do
+        [[ "$other" == "$first" ]] && continue
+        doctor_note "also installed: ${other} (version $(doctor_file_version "$other"))"
+    done
+    return 0
+}
+
+doctor_check_schedule() {
+    doctor_heading 'Schedule'
+
+    local agents_dir="${ASIMOV_ROOT}/Library/LaunchAgents"
+    local label plist program active=0
+
+    for label in "${ASIMOV_DOCTOR_LABELS[@]}"; do
+        plist="${agents_dir}/${label}.plist"
+        [[ -f "$plist" ]] || continue
+        active=$((active + 1))
+
+        program="$(plutil -extract Program raw "$plist" 2>/dev/null || true)"
+        if [[ -n "$program" && ! -x "$program" ]]; then
+            doctor_problem "${label}: its program ${program} no longer exists"
+            doctor_fix "launchctl bootout gui/\$(id -u)/${label}"
+            doctor_fix "rm ${plist}"
+            continue
+        fi
+
+        if launchctl list "$label" >/dev/null 2>&1; then
+            doctor_ok "${label} — loaded, runs daily"
+        elif [[ "$label" == "$ASIMOV_CURRENT_LABEL" ]]; then
+            doctor_problem "${label}: installed but not loaded, so it never runs"
+            doctor_fix "launchctl bootstrap gui/\$(id -u) ${plist}"
+        else
+            # A label we no longer ship, sitting unloaded: a leftover from an
+            # older install. Loading it is never the right advice.
+            doctor_problem "${label}: leftover from an older install, not loaded"
+            doctor_fix "rm ${plist}"
+        fi
+    done
+
+    if [[ "$active" -eq 0 ]]; then
+        doctor_note "not scheduled — Asimov only runs when you run it"
+    elif [[ "$active" -gt 1 ]]; then
+        doctor_problem "more than one schedule is installed (${active}) — they will both run"
+        doctor_fix "Keep com.stevegrunwell.asimov and bootout the rest."
+    fi
+    return 0
+}
+
+# Humanise an age in seconds: "3 minutes ago", "2 days ago".
+doctor_humanise_age() {
+    local seconds="$1" value unit
+    if   [[ "$seconds" -lt 60 ]];    then printf 'just now\n'; return 0
+    elif [[ "$seconds" -lt 3600 ]];  then value=$((seconds / 60));    unit=minute
+    elif [[ "$seconds" -lt 86400 ]]; then value=$((seconds / 3600));  unit=hour
+    else                                  value=$((seconds / 86400)); unit=day
+    fi
+    printf '%s %s%s ago\n' "$value" "$unit" "$([[ "$value" -eq 1 ]] || echo s)"
+}
+
+doctor_check_cache() {
+    doctor_heading 'Cache'
+
+    if [[ ! -d "$ASIMOV_CACHE_DIR" ]]; then
+        doctor_ok "no cache yet — the next run builds one"
+        return 0
+    fi
+
+    if [[ ! -w "$ASIMOV_CACHE_DIR" ]]; then
+        doctor_problem "${ASIMOV_CACHE_DIR} is not writable by you"
+        doctor_fix "rm -rf ${ASIMOV_CACHE_DIR}"
+        return 0
+    fi
+
+    local file owner broken=0 root_owned=0
+    for file in "$ASIMOV_EXCLUDED_STATE" "$ASIMOV_FAILED_STATE" \
+                "$ASIMOV_MDFIND_SEEN" "$ASIMOV_PATH_CACHE"; do
+        [[ -e "$file" ]] || continue
+        if [[ ! -r "$file" || ! -w "$file" ]]; then
+            broken=$((broken + 1))
+            owner="$(stat -f '%Su' "$file" 2>/dev/null || echo 'unknown')"
+            [[ "$owner" == "root" ]] && root_owned=$((root_owned + 1))
+            doctor_problem "${file} is not readable and writable by you (owner: ${owner})"
+        fi
+    done
+
+    if [[ "$broken" -gt 0 ]]; then
+        # Only name root as the cause when root actually owns something: a
+        # diagnosis that guesses wrong sends people chasing the wrong fix.
+        if [[ "$root_owned" -gt 0 ]]; then
+            doctor_fix "A run as root left these behind. Clear them:"
+        else
+            doctor_fix "Asimov can't use these. Clear them:"
+        fi
+        doctor_fix "rm -rf ${ASIMOV_CACHE_DIR}"
+        return 0
+    fi
+
+    if [[ -r "$ASIMOV_PATH_CACHE" ]]; then
+        local entries age
+        entries="$(grep -cve '^#' -e '^$' "$ASIMOV_PATH_CACHE" 2>/dev/null || true)"
+        doctor_ok "${entries:-0} cached paths"
+        age="$(( $(date +%s) - $(stat -f '%m' "$ASIMOV_PATH_CACHE" 2>/dev/null || date +%s) ))"
+        doctor_ok "last scan: $(doctor_humanise_age "$age")"
+    else
+        doctor_ok "cache is readable, no scan recorded yet"
+    fi
+    return 0
+}
+
+doctor_check_config() {
+    doctor_heading 'Config'
+
+    local config_file="${ASIMOV_ROOT}/.config/asimov/config"
+    if [[ ! -f "$config_file" ]]; then
+        doctor_note "no config file — using defaults"
+        return 0
+    fi
+    if [[ ! -r "$config_file" ]]; then
+        doctor_problem "${config_file} is not readable by you"
+        return 0
+    fi
+
+    # Same grammar load_config accepts, but here anything unrecognised is
+    # reported instead of silently ignored — a typo'd key is invisible otherwise.
+    local section="" line key unknown=0
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        line="${line%%#*}"
+        line="${line#"${line%%[![:space:]]*}"}"
+        line="${line%"${line##*[![:space:]]}"}"
+        [[ -z "$line" ]] && continue
+
+        if [[ "$line" =~ ^\[([a-z_]+)\]$ ]]; then
+            section="${BASH_REMATCH[1]}"
+            case "$section" in
+                fixed_dirs|scan|sentinels) ;;
+                *)
+                    unknown=$((unknown + 1))
+                    doctor_problem "unknown section [${section}] in ${config_file}"
+                    ;;
+            esac
+            continue
+        fi
+
+        if [[ "$line" =~ ^([a-z_]+)[[:space:]]*=[[:space:]]*(.*)$ ]]; then
+            key="${BASH_REMATCH[1]}"
+            case "${section}:${key}" in
+                fixed_dirs:enabled|fixed_dirs:extra|scan:extra|\
+                sentinels:extra|sentinels:disabled) ;;
+                *)
+                    # A key under an already-reported section is the same fault.
+                    case "$section" in
+                        fixed_dirs|scan|sentinels)
+                            unknown=$((unknown + 1))
+                            doctor_problem "unknown key '${key}' under [${section}] in ${config_file}"
+                            ;;
+                    esac
+                    ;;
+            esac
+        fi
+    done < "$config_file"
+
+    [[ "$unknown" -eq 0 ]] && doctor_ok "${config_file} looks valid"
+    return 0
+}
+
+doctor_check_time_machine() {
+    doctor_heading 'Time Machine'
+
+    if ! command -v tmutil >/dev/null 2>&1; then
+        doctor_problem "tmutil not found — is this macOS?"
+        return 0
+    fi
+
+    if tmutil isexcluded "$ASIMOV_ROOT" >/dev/null 2>&1; then
+        doctor_ok "tmutil can read exclusions"
+    else
+        doctor_problem "tmutil cannot read exclusions — grant your terminal Full Disk Access"
+        doctor_fix "System Settings → Privacy & Security → Full Disk Access"
+    fi
+    return 0
+}
+
+cmd_doctor() {
+    [[ -n "$ASIMOV_QUIET" ]] || printf '\n%sAsimov doctor%s\n' \
+        "$ASIMOV_COLOR_INFO" "$ASIMOV_COLOR_RESET"
+
+    doctor_check_install
+    doctor_check_schedule
+    doctor_check_cache
+    doctor_check_config
+    doctor_check_time_machine
+
+    if [[ "$ASIMOV_DOCTOR_PROBLEMS" -eq 0 ]]; then
+        [[ -n "$ASIMOV_QUIET" ]] || printf '\n%s✓%s No problems found.\n\n' \
+            "$ASIMOV_COLOR_SUCCESS" "$ASIMOV_COLOR_RESET"
+        return 0
+    fi
+
+    printf '\n%s problem%s found.\n\n' "$ASIMOV_DOCTOR_PROBLEMS" \
+        "$([[ "$ASIMOV_DOCTOR_PROBLEMS" -eq 1 ]] || echo s)"
+    return 1
+}
+
+if [[ "$ASIMOV_COMMAND" == "doctor" ]]; then
+    cmd_doctor
+    exit $?
 fi
 
 # Load optional config from ~/.config/asimov/config.
@@ -407,7 +809,7 @@ readonly -a ASIMOV_SCAN_DIRS
 # When not writing (--no-cache / --no-write-cache), leave every cache file untouched.
 # (The paths cache is truncated separately by init_path_cache before the full scan.)
 if [[ -n "$ASIMOV_NO_READ_CACHE" && -z "$ASIMOV_NO_WRITE_CACHE" ]]; then
-    rm -f "$ASIMOV_EXCLUDED_STATE" "$ASIMOV_FAILED_STATE" "$ASIMOV_MDFIND_SEEN"
+    rm -f "$ASIMOV_EXCLUDED_STATE" "$ASIMOV_FAILED_STATE" "$ASIMOV_MDFIND_SEEN" 2>/dev/null || true
 fi
 
 # Build a cache of paths already excluded from Time Machine.
@@ -428,11 +830,11 @@ spotlight_count="$(wc -l < "$ASIMOV_EXCLUDED_CACHE" | tr -d ' ')"
 # skips them instantly instead of wasting time retrying tmutil.
 # Skipped under --no-read-cache (--full-scan / --no-cache): every path is then
 # re-verified against the tmutil isexcluded ground truth instead.
-if [[ -z "$ASIMOV_NO_READ_CACHE" ]] && { [[ -f "$ASIMOV_EXCLUDED_STATE" ]] || [[ -f "$ASIMOV_FAILED_STATE" ]]; }; then
+if [[ -z "$ASIMOV_NO_READ_CACHE" ]] && { cache_readable "$ASIMOV_EXCLUDED_STATE" || cache_readable "$ASIMOV_FAILED_STATE"; }; then
     {
         cat "$ASIMOV_EXCLUDED_CACHE"
-        if [[ -f "$ASIMOV_EXCLUDED_STATE" ]]; then cat "$ASIMOV_EXCLUDED_STATE"; fi
-        if [[ -f "$ASIMOV_FAILED_STATE" ]]; then cat "$ASIMOV_FAILED_STATE"; fi
+        if cache_readable "$ASIMOV_EXCLUDED_STATE"; then cat "$ASIMOV_EXCLUDED_STATE"; fi
+        if cache_readable "$ASIMOV_FAILED_STATE"; then cat "$ASIMOV_FAILED_STATE"; fi
     } | sort -u > "${ASIMOV_EXCLUDED_CACHE}.merged"
     mv -f "${ASIMOV_EXCLUDED_CACHE}.merged" "$ASIMOV_EXCLUDED_CACHE"
 fi
@@ -444,22 +846,33 @@ verbose_timing "Excluded-path cache ready ($(wc -l < "$ASIMOV_EXCLUDED_CACHE" | 
 
 # Create the cache directory, chown to console user when running as root.
 ensure_cache_dir() {
-    local cache_dir
-    cache_dir="$(dirname "$ASIMOV_PATH_CACHE")"
-    mkdir -p "$cache_dir"
+    if [[ ! -d "$ASIMOV_CACHE_DIR" ]]; then
+        mkdir -p "$ASIMOV_CACHE_DIR" 2>/dev/null || {
+            warn_unusable_cache "$ASIMOV_CACHE_DIR" "writable"
+            return 0
+        }
+    fi
     if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
         local console_user
         console_user="$(stat -f '%Su' /dev/console 2>/dev/null || echo '')"
         if [[ -n "$console_user" && "$console_user" != "root" ]]; then
-            chown -R "$console_user" "$cache_dir" 2>/dev/null || true
+            # Create the state files *before* the chown. Appending to an existing
+            # file never changes its owner, so every write later in this root run
+            # lands in a file the console user can still read next time. Chowning
+            # only the directory (as this did before) left root-owned files behind
+            # that broke the following user run outright — issue #122.
+            touch "$ASIMOV_EXCLUDED_STATE" "$ASIMOV_FAILED_STATE" \
+                  "$ASIMOV_MDFIND_SEEN" "$ASIMOV_PATH_CACHE" 2>/dev/null || true
+            chown -R "$console_user" "$ASIMOV_CACHE_DIR" 2>/dev/null || true
         fi
     fi
+    return 0
 }
 
 # Read cached paths, filtering to those that still exist as directories
 # and fall under one of the scan dirs. Outputs valid paths to stdout.
 read_path_cache() {
-    [[ -f "$ASIMOV_PATH_CACHE" ]] || return 0
+    cache_readable "$ASIMOV_PATH_CACHE" || return 0
     local line d in_scope
     while IFS= read -r line; do
         # Skip comments and blank lines
@@ -482,13 +895,14 @@ read_path_cache() {
 init_path_cache() {
     [[ -n "$ASIMOV_DRY_RUN" || -n "$ASIMOV_NO_WRITE_CACHE" ]] && return 0
     ensure_cache_dir
+    cache_writable "$ASIMOV_PATH_CACHE" || return 0
     printf '# asimov path cache — updated %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" > "$ASIMOV_PATH_CACHE"
 }
 
 # Append a single path to the cache file. No-op if --dry-run or writes are disabled (--no-write-cache / --no-cache).
 append_path_to_cache() {
     [[ -n "$ASIMOV_DRY_RUN" || -n "$ASIMOV_NO_WRITE_CACHE" ]] && return 0
-    printf '%s\n' "$1" >> "$ASIMOV_PATH_CACHE"
+    append_state "$1" "$ASIMOV_PATH_CACHE"
 }
 
 # Remove paths that are descendants of other paths in the list.
@@ -511,7 +925,8 @@ dedup_nested_paths() {
 # Writes atomically via temp file + mv. No-op if --dry-run or writes are disabled (--no-write-cache / --no-cache).
 finalize_path_cache() {
     [[ -n "$ASIMOV_DRY_RUN" || -n "$ASIMOV_NO_WRITE_CACHE" ]] && return 0
-    [[ -f "$ASIMOV_PATH_CACHE" ]] || return 0
+    cache_readable "$ASIMOV_PATH_CACHE" || return 0
+    cache_writable "$ASIMOV_PATH_CACHE" || return 0
 
     ASIMOV_PATH_CACHE_TMP="${ASIMOV_PATH_CACHE}.tmp.$$"
     {
@@ -529,13 +944,13 @@ finalize_path_cache() {
     ASIMOV_PATH_CACHE_TMP=""
 
     # Dedup the mdfind_seen file (grows with appends each run)
-    if [[ -f "$ASIMOV_MDFIND_SEEN" ]]; then
+    if cache_readable "$ASIMOV_MDFIND_SEEN" && cache_writable "$ASIMOV_MDFIND_SEEN"; then
         sort -u "$ASIMOV_MDFIND_SEEN" > "${ASIMOV_MDFIND_SEEN}.tmp"
         mv -f "${ASIMOV_MDFIND_SEEN}.tmp" "$ASIMOV_MDFIND_SEEN"
     fi
 
     # Dedup the failed-state file (grows with appends each run)
-    if [[ -f "$ASIMOV_FAILED_STATE" ]]; then
+    if cache_readable "$ASIMOV_FAILED_STATE" && cache_writable "$ASIMOV_FAILED_STATE"; then
         sort -u "$ASIMOV_FAILED_STATE" > "${ASIMOV_FAILED_STATE}.tmp"
         mv -f "${ASIMOV_FAILED_STATE}.tmp" "$ASIMOV_FAILED_STATE"
     fi
@@ -645,7 +1060,7 @@ discover_new_paths_via_mdfind() {
     combined_filter="$(mktemp)"
     {
         if [[ -n "$cached_paths_file" && -s "$cached_paths_file" ]]; then cat "$cached_paths_file"; fi
-        if [[ -f "$ASIMOV_MDFIND_SEEN" ]]; then cat "$ASIMOV_MDFIND_SEEN"; fi
+        if cache_readable "$ASIMOV_MDFIND_SEEN"; then cat "$ASIMOV_MDFIND_SEEN"; fi
     } > "$combined_filter"
     if [[ -s "$combined_filter" ]]; then
         local sorted_candidates sorted_filter filtered_file
@@ -729,7 +1144,9 @@ discover_new_paths_via_mdfind() {
     # No-op for dry-run/no-cache (no persistent state should be written).
     if [[ -z "$ASIMOV_DRY_RUN" && -z "$ASIMOV_NO_WRITE_CACHE" ]]; then
         ensure_cache_dir
-        cat "$uncached_file" >> "$ASIMOV_MDFIND_SEEN"
+        if cache_writable "$ASIMOV_MDFIND_SEEN"; then
+            cat "$uncached_file" >> "$ASIMOV_MDFIND_SEEN"
+        fi
     fi
     rm -f "$uncached_file"
     verbose_timing "Spotlight: checked ${mdfind_checked} candidates, ${mdfind_matched} new matches"
@@ -945,7 +1362,7 @@ exclude_paths_from_stdin() {
         if tmutil isexcluded "$path" 2>/dev/null | grep -Fq '[Excluded]'; then
             skipped_already=$((skipped_already + 1))
             # Persist so we skip it via the fast cache next time (not in dry-run / no-write)
-            [[ -z "$ASIMOV_DRY_RUN" && -z "$ASIMOV_NO_WRITE_CACHE" ]] && printf '%s\n' "$path" >> "$ASIMOV_EXCLUDED_STATE"
+            [[ -z "$ASIMOV_DRY_RUN" && -z "$ASIMOV_NO_WRITE_CACHE" ]] && append_state "$path" "$ASIMOV_EXCLUDED_STATE"
             if [[ -n "$ASIMOV_VERBOSE" ]]; then
                 echo "- ${path} is already excluded, skipping."
             fi
@@ -962,7 +1379,7 @@ exclude_paths_from_stdin() {
         # deliberately 0555. Check first: addexclusion costs ~11s even when it fails.
         if [[ ! -w "$path" ]]; then
             echo "! ${path}: read-only, cannot be excluded — skipping." >&2
-            [[ -z "$ASIMOV_NO_WRITE_CACHE" ]] && printf '%s\n' "$path" >> "$ASIMOV_FAILED_STATE"
+            [[ -z "$ASIMOV_NO_WRITE_CACHE" ]] && append_state "$path" "$ASIMOV_FAILED_STATE"
             continue
         fi
         # tmutil prints its POSIXError dump to stdout, not stderr — silence both.
@@ -970,11 +1387,11 @@ exclude_paths_from_stdin() {
             echo "! ${path}: failed to exclude (tmutil error), skipping." >&2
             # Persist failure so we skip this path on subsequent runs.
             # Use --no-read-cache to retry.
-            [[ -z "$ASIMOV_NO_WRITE_CACHE" ]] && printf '%s\n' "$path" >> "$ASIMOV_FAILED_STATE"
+            [[ -z "$ASIMOV_NO_WRITE_CACHE" ]] && append_state "$path" "$ASIMOV_FAILED_STATE"
             continue
         fi
         # Persist immediately — survives Ctrl+C so the next run doesn't redo this path
-        [[ -z "$ASIMOV_NO_WRITE_CACHE" ]] && printf '%s\n' "$path" >> "$ASIMOV_EXCLUDED_STATE"
+        [[ -z "$ASIMOV_NO_WRITE_CACHE" ]] && append_state "$path" "$ASIMOV_EXCLUDED_STATE"
         record_excluded_path "$path" "${path} has been excluded from Time Machine backups"
         verbose_timing "  [${tmutil_i}/${#to_exclude[@]}] excluded in $((SECONDS - path_start))s: ${path}"
     done
@@ -1126,7 +1543,7 @@ fi
 # Cache is read when the cache file exists and reads aren't disabled
 # (--no-read-cache / --full-scan / --no-cache force a full scan).
 use_cache=false
-if [[ -z "$ASIMOV_NO_READ_CACHE" && -f "$ASIMOV_PATH_CACHE" ]]; then
+if [[ -z "$ASIMOV_NO_READ_CACHE" ]] && cache_readable "$ASIMOV_PATH_CACHE"; then
     use_cache=true
 fi
 
@@ -1183,7 +1600,11 @@ else
     # On interrupt, tee has already appended every path find emitted, so the
     # next run can use the partial cache.
     verbose_timing "Starting find traversal of ${ASIMOV_SCAN_DIRS[*]}…"
-    if [[ -z "$ASIMOV_DRY_RUN" && -z "$ASIMOV_NO_WRITE_CACHE" ]]; then
+    # The tee'd branch is only safe when the cache is actually writable: a failing
+    # tee takes the whole pipeline down under pipefail. Fall back to the plain
+    # pipeline otherwise, so an unusable cache costs speed, not the run (#122).
+    if [[ -z "$ASIMOV_DRY_RUN" && -z "$ASIMOV_NO_WRITE_CACHE" ]] \
+        && { ensure_cache_dir; cache_writable "$ASIMOV_PATH_CACHE"; }; then
         init_path_cache
         { find "${ASIMOV_SCAN_DIRS[@]}" \( "${find_parameters_skip[@]}" \) \( -false "${find_parameters_vendor[@]}" \) \
             || true; } | tee -a "$ASIMOV_PATH_CACHE" | exclude_paths_from_stdin

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -14,6 +14,7 @@ readonly TEST_FILES=(
     tests/sentinels.bats
     tests/behavior.bats
     tests/cache.bats
+    tests/doctor.bats
     tests/format.bats
     tests/plist.bats
 )

--- a/tests/bin/launchctl
+++ b/tests/bin/launchctl
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Mock launchctl for the Asimov test suite.
+#
+# Only the subcommands `asimov doctor` uses are implemented. The set of loaded
+# labels comes from ASIMOV_TEST_LAUNCHCTL_LOADED (space-separated); anything
+# else is reported as not loaded, exactly as the real launchctl does.
+
+set -eu
+
+case "${1:-}" in
+    list)
+        label="${2:-}"
+        if [[ -z "$label" ]]; then
+            for loaded in ${ASIMOV_TEST_LAUNCHCTL_LOADED:-}; do
+                printf -- '-\t0\t%s\n' "$loaded"
+            done
+            exit 0
+        fi
+        for loaded in ${ASIMOV_TEST_LAUNCHCTL_LOADED:-}; do
+            if [[ "$loaded" == "$label" ]]; then
+                printf '{\n\t"Label" = "%s";\n};\n' "$label"
+                exit 0
+            fi
+        done
+        echo "Could not find service \"${label}\"" >&2
+        exit 113
+        ;;
+    *)
+        exit 0
+        ;;
+esac

--- a/tests/bin/tmutil
+++ b/tests/bin/tmutil
@@ -18,6 +18,12 @@ shift || true
 case "$subcommand" in
   isexcluded)
     path="${1:-}"
+    # Simulate tmutil being unable to read exclusions at all — what a Mac
+    # without Full Disk Access looks like to `asimov doctor`.
+    if [[ -n "${ASIMOV_TEST_TMUTIL_ISEXCLUDED_FAIL:-}" ]]; then
+      echo "tmutil: unable to read exclusion setting" >&2
+      exit 1
+    fi
     # A path is excluded if it — or any ancestor directory — is in the exclusion
     # database. Real tmutil reports descendants of a path-based exclusion as
     # excluded too (TM exclusions are recursive), so a manually excluded parent

--- a/tests/cache.bats
+++ b/tests/cache.bats
@@ -408,3 +408,113 @@ load test_helper
   [[ "$status" -eq 0 ]]
   [[ "$output" == *"Using cached paths"* ]]
 }
+
+# =============================================================================
+# Unusable cache files (issue #122)
+#
+# A cache is an optimisation. An unreadable or unwritable state file — the state
+# a run as root leaves behind — must degrade the run, never abort it.
+# =============================================================================
+
+# These tests make files unreadable/unwritable, which has no effect as root.
+require_non_root() {
+  if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+    skip "chmod-based tests are meaningless as root"
+  fi
+}
+
+@test "run survives an unreadable excluded-state file" {
+  require_non_root
+  create_project "Code/My-Project" "package.json" "node_modules"
+  mkdir -p "${HOME}/.cache/asimov"
+  echo "/some/old/path" > "${HOME}/.cache/asimov/excluded"
+  chmod 000 "${HOME}/.cache/asimov/excluded"
+
+  run_asimov
+  chmod 644 "${HOME}/.cache/asimov/excluded"
+
+  [[ "$status" -eq 0 ]]
+  assert_excluded "${HOME}/Code/My-Project/node_modules"
+}
+
+@test "unreadable cache prints a warning naming the reset command" {
+  require_non_root
+  create_project "Code/My-Project" "package.json" "node_modules"
+  mkdir -p "${HOME}/.cache/asimov"
+  echo "/some/old/path" > "${HOME}/.cache/asimov/excluded"
+  chmod 000 "${HOME}/.cache/asimov/excluded"
+
+  run_asimov
+  chmod 644 "${HOME}/.cache/asimov/excluded"
+
+  [[ "$output" == *"is not readable"* ]]
+  [[ "$output" == *"rm -rf ${HOME}/.cache/asimov"* ]]
+}
+
+@test "unreadable cache warns once, not once per file" {
+  require_non_root
+  create_project "Code/My-Project" "package.json" "node_modules"
+  mkdir -p "${HOME}/.cache/asimov"
+  echo "/some/old/path" > "${HOME}/.cache/asimov/excluded"
+  echo "/some/old/path" > "${HOME}/.cache/asimov/failed"
+  chmod 000 "${HOME}/.cache/asimov/excluded" "${HOME}/.cache/asimov/failed"
+
+  run_asimov
+  chmod 644 "${HOME}/.cache/asimov/excluded" "${HOME}/.cache/asimov/failed"
+
+  local warnings
+  warnings="$(printf '%s\n' "$output" | grep -c "continuing without the cache" || true)"
+  [[ "$warnings" -eq 1 ]]
+}
+
+@test "run survives an unwritable cache directory" {
+  require_non_root
+  create_project "Code/My-Project" "package.json" "node_modules"
+  mkdir -p "${HOME}/.cache/asimov"
+  chmod 500 "${HOME}/.cache/asimov"
+
+  run_asimov
+  chmod 700 "${HOME}/.cache/asimov"
+
+  [[ "$status" -eq 0 ]]
+  assert_excluded "${HOME}/Code/My-Project/node_modules"
+}
+
+@test "full scan survives an unwritable path cache file" {
+  require_non_root
+  create_project "Code/My-Project" "package.json" "node_modules"
+  write_path_cache
+  chmod 400 "${HOME}/.cache/asimov/paths"
+
+  # --full-scan has to rewrite the cache, so this exercises the tee'd pipeline
+  # that a read-only run never reaches.
+  run_asimov --full-scan
+  chmod 644 "${HOME}/.cache/asimov/paths"
+
+  [[ "$status" -eq 0 ]]
+  assert_excluded "${HOME}/Code/My-Project/node_modules"
+}
+
+@test "cached run with an unwritable path cache still excludes what it cached" {
+  require_non_root
+  create_project "Code/My-Project" "package.json" "node_modules"
+  write_path_cache "${HOME}/Code/My-Project/node_modules"
+  chmod 400 "${HOME}/.cache/asimov/paths"
+
+  run_asimov
+  chmod 644 "${HOME}/.cache/asimov/paths"
+
+  [[ "$status" -eq 0 ]]
+  assert_excluded "${HOME}/Code/My-Project/node_modules"
+}
+
+@test "prune survives an unreadable path cache" {
+  require_non_root
+  write_path_cache "${HOME}/gone"
+  chmod 000 "${HOME}/.cache/asimov/paths"
+
+  run_asimov prune
+  chmod 644 "${HOME}/.cache/asimov/paths"
+
+  [[ "$status" -eq 0 ]]
+}

--- a/tests/doctor.bats
+++ b/tests/doctor.bats
@@ -1,0 +1,319 @@
+#!/usr/bin/env bats
+#
+# Tests for `asimov doctor` — the diagnostic subcommand.
+#
+# Doctor exists mainly for people arriving from v0.3.0 (issue #122), where the
+# failure modes are leftovers: a shadowed binary, an orphaned LaunchAgent, and a
+# root-owned cache. It is read-only: it reports and prints commands, never runs
+# them, and never executes another asimov binary it finds.
+
+load test_helper
+
+# The shared setup() from test_helper applies. With ASIMOV_TEST_LAUNCHCTL_LOADED
+# unset, the mock launchctl reports nothing as loaded — the right baseline.
+
+require_non_root() {
+  if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+    skip "chmod-based tests are meaningless as root"
+  fi
+}
+
+# =============================================================================
+# Plumbing
+# =============================================================================
+
+@test "doctor runs and exits 0 on a clean system" {
+  run_asimov doctor
+  [[ "$status" -eq 0 ]]
+}
+
+@test "doctor is listed in the help output" {
+  run_asimov --help
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"asimov doctor"* ]]
+}
+
+@test "doctor reports the running version" {
+  run_asimov doctor
+  [[ "$output" == *"0.10.0"* ]]
+}
+
+@test "doctor never modifies Time Machine exclusions" {
+  create_project "Code/My-Project" "package.json" "node_modules"
+
+  run_asimov doctor
+
+  [[ "$(count_exclusions)" -eq 0 ]]
+  refute_excluded "${HOME}/Code/My-Project/node_modules"
+}
+
+@test "doctor does not create a cache" {
+  run_asimov doctor
+  [[ ! -e "${HOME}/.cache/asimov/paths" ]]
+}
+
+@test "doctor --quiet prints nothing when everything is healthy" {
+  run_asimov doctor --quiet
+  [[ "$status" -eq 0 ]]
+  [[ -z "$output" ]]
+}
+
+# =============================================================================
+# Install / shadowed binaries
+# =============================================================================
+
+@test "doctor flags an older asimov shadowing the one that is running" {
+  shadow_asimov_binary "0.3.0" >/dev/null
+
+  run_asimov doctor
+
+  [[ "$status" -eq 1 ]]
+  [[ "$output" == *"shadow"* ]]
+  [[ "$output" == *"0.3.0"* ]]
+}
+
+@test "doctor reads the shadowing binary's version without executing it" {
+  shadow_asimov_binary "0.3.0" >/dev/null
+
+  run_asimov doctor
+
+  # The stub screams if it is ever run. v0.3.0 parses no arguments at all, so
+  # executing it to ask its version would start a real scan instead.
+  [[ "$output" != *"STUB WAS EXECUTED"* ]]
+}
+
+@test "doctor is clean when no other asimov is on PATH" {
+  run_asimov doctor
+  [[ "$output" != *"shadow"* ]]
+}
+
+# =============================================================================
+# Schedule
+# =============================================================================
+
+@test "doctor reports a loaded schedule as healthy" {
+  write_launch_agent "com.stevegrunwell.asimov" "$(command -v bash)"
+  set_loaded_agents "com.stevegrunwell.asimov"
+
+  run_asimov doctor
+
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"com.stevegrunwell.asimov"* ]]
+  [[ "$output" == *"loaded"* ]]
+}
+
+@test "doctor flags a plist whose program no longer exists" {
+  write_launch_agent "homebrew.mxcl.asimov" "/opt/homebrew/Cellar/asimov/0.3.0/bin/asimov"
+  set_loaded_agents "homebrew.mxcl.asimov"
+
+  run_asimov doctor
+
+  [[ "$status" -eq 1 ]]
+  [[ "$output" == *"homebrew.mxcl.asimov"* ]]
+  [[ "$output" == *"/opt/homebrew/Cellar/asimov/0.3.0/bin/asimov"* ]]
+  [[ "$output" == *"no longer exists"* ]]
+}
+
+@test "doctor flags two schedules running at once" {
+  write_launch_agent "com.stevegrunwell.asimov" "$(command -v bash)"
+  write_launch_agent "com.django23.asimov" "$(command -v bash)"
+  set_loaded_agents "com.stevegrunwell.asimov com.django23.asimov"
+
+  run_asimov doctor
+
+  [[ "$status" -eq 1 ]]
+  [[ "$output" == *"two schedules"* || "$output" == *"more than one"* ]]
+}
+
+@test "doctor prints the bootout command for an orphaned agent" {
+  write_launch_agent "homebrew.mxcl.asimov" "/gone/asimov"
+  set_loaded_agents "homebrew.mxcl.asimov"
+
+  run_asimov doctor
+
+  [[ "$output" == *"launchctl bootout"* ]]
+  [[ "$output" == *"homebrew.mxcl.asimov"* ]]
+}
+
+@test "doctor says so when nothing is scheduled" {
+  run_asimov doctor
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"not scheduled"* ]]
+}
+
+@test "doctor treats an unloaded legacy agent as a leftover to remove" {
+  write_launch_agent "com.django23.asimov" "$(command -v bash)"
+  set_loaded_agents
+
+  run_asimov doctor
+
+  [[ "$status" -eq 1 ]]
+  [[ "$output" == *"leftover"* ]]
+  [[ "$output" == *"rm ${HOME}/Library/LaunchAgents/com.django23.asimov.plist"* ]]
+  # Never advise loading a label we no longer ship.
+  [[ "$output" != *"bootstrap"* ]]
+}
+
+@test "doctor offers to load an unloaded current agent" {
+  write_launch_agent "com.stevegrunwell.asimov" "$(command -v bash)"
+  set_loaded_agents
+
+  run_asimov doctor
+
+  [[ "$output" == *"bootstrap"* ]]
+}
+
+@test "doctor flags a plist that is installed but not loaded" {
+  write_launch_agent "com.stevegrunwell.asimov" "$(command -v bash)"
+  set_loaded_agents
+
+  run_asimov doctor
+
+  [[ "$output" == *"not loaded"* ]]
+}
+
+# =============================================================================
+# Cache
+# =============================================================================
+
+@test "doctor flags an unreadable cache file and prints the reset command" {
+  require_non_root
+  mkdir -p "${HOME}/.cache/asimov"
+  echo "/x" > "${HOME}/.cache/asimov/excluded"
+  chmod 000 "${HOME}/.cache/asimov/excluded"
+
+  run_asimov doctor
+  chmod 644 "${HOME}/.cache/asimov/excluded"
+
+  [[ "$status" -eq 1 ]]
+  [[ "$output" == *"excluded"* ]]
+  [[ "$output" == *"rm -rf ${HOME}/.cache/asimov"* ]]
+}
+
+@test "doctor does not blame root for a cache file you own" {
+  require_non_root
+  mkdir -p "${HOME}/.cache/asimov"
+  echo "/x" > "${HOME}/.cache/asimov/excluded"
+  chmod 000 "${HOME}/.cache/asimov/excluded"
+
+  run_asimov doctor
+  chmod 644 "${HOME}/.cache/asimov/excluded"
+
+  [[ "$status" -eq 1 ]]
+  [[ "$output" == *"rm -rf ${HOME}/.cache/asimov"* ]]
+  # The file is owned by the current user; root never touched it.
+  [[ "$output" != *"as root"* ]]
+}
+
+@test "doctor flags an unwritable cache directory" {
+  require_non_root
+  mkdir -p "${HOME}/.cache/asimov"
+  chmod 500 "${HOME}/.cache/asimov"
+
+  run_asimov doctor
+  chmod 700 "${HOME}/.cache/asimov"
+
+  [[ "$status" -eq 1 ]]
+  [[ "$output" == *"not writable"* ]]
+}
+
+@test "doctor reports a healthy cache with its entry count" {
+  write_path_cache "${HOME}/a" "${HOME}/b"
+
+  run_asimov doctor
+
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"2"* ]]
+}
+
+@test "doctor says when the last scan ran" {
+  write_path_cache "${HOME}/a"
+
+  run_asimov doctor
+
+  [[ "$output" == *"last scan"* ]]
+}
+
+@test "doctor reports no cache yet as healthy, not a problem" {
+  run_asimov doctor
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"no cache yet"* ]]
+}
+
+# =============================================================================
+# Config
+# =============================================================================
+
+@test "doctor reports a valid config file" {
+  write_config "[fixed_dirs]
+enabled = true"
+
+  run_asimov doctor
+
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *".config/asimov/config"* ]]
+}
+
+@test "doctor flags an unknown config key" {
+  write_config "[fixed_dirs]
+enbaled = true"
+
+  run_asimov doctor
+
+  [[ "$status" -eq 1 ]]
+  [[ "$output" == *"enbaled"* ]]
+}
+
+@test "doctor flags an unknown config section" {
+  write_config "[fixed_dris]
+enabled = true"
+
+  run_asimov doctor
+
+  [[ "$status" -eq 1 ]]
+  [[ "$output" == *"fixed_dris"* ]]
+}
+
+@test "doctor reports the default when there is no config file" {
+  run_asimov doctor
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"defaults"* ]]
+}
+
+# =============================================================================
+# Time Machine
+# =============================================================================
+
+@test "doctor reports tmutil as reachable" {
+  run_asimov doctor
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == *"Time Machine"* ]]
+}
+
+@test "doctor flags tmutil being unable to read exclusions" {
+  ASIMOV_TEST_TMUTIL_ISEXCLUDED_FAIL=1
+  export ASIMOV_TEST_TMUTIL_ISEXCLUDED_FAIL
+
+  run_asimov doctor
+
+  [[ "$status" -eq 1 ]]
+  [[ "$output" == *"Full Disk Access"* ]]
+}
+
+# =============================================================================
+# Summary
+# =============================================================================
+
+@test "doctor summarises the problem count" {
+  write_launch_agent "homebrew.mxcl.asimov" "/gone/asimov"
+  set_loaded_agents "homebrew.mxcl.asimov"
+
+  run_asimov doctor
+
+  [[ "$output" == *"1 problem"* ]]
+}
+
+@test "doctor says everything checks out when healthy" {
+  run_asimov doctor
+  [[ "$output" == *"No problems found"* ]]
+}

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -8,6 +8,17 @@ setup() {
   export HOME="$TEST_TEMP_DIR"
   export PATH="${BATS_TEST_DIRNAME}/bin:$PATH"
 
+  # Drop any real asimov install from PATH. `asimov doctor` inspects PATH, so
+  # without this the suite would report a different result on every machine
+  # depending on whether the developer has asimov installed, and which version.
+  local clean_path="" path_dir
+  while IFS= read -r path_dir; do
+    [[ -n "$path_dir" ]] || continue
+    [[ -x "${path_dir}/asimov" ]] && continue
+    clean_path="${clean_path:+${clean_path}:}${path_dir}"
+  done < <(printf '%s\n' "${PATH//:/$'\n'}")
+  export PATH="$clean_path"
+
   ASIMOV_TEST_EXCLUSIONS="${TEST_TEMP_DIR}/.exclusions"
   export ASIMOV_TEST_EXCLUSIONS
   touch "$ASIMOV_TEST_EXCLUSIONS"
@@ -200,4 +211,58 @@ write_sticky_exclusions() {
         /usr/libexec/PlistBuddy -c "Add :SkipPaths: string ${path}" "$plist" >/dev/null
     done
     export ASIMOV_TM_PLIST="$plist"
+}
+
+# Write a LaunchAgent plist into the (temp) home, as an install would.
+#
+# Usage: write_launch_agent <label> [program_path]
+#
+# Example: write_launch_agent "homebrew.mxcl.asimov" "/opt/homebrew/bin/asimov"
+write_launch_agent() {
+    local label="$1"
+    local program="${2:-/usr/local/bin/asimov}"
+    local dir="${HOME}/Library/LaunchAgents"
+    mkdir -p "$dir"
+    cat > "${dir}/${label}.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${label}</string>
+    <key>Program</key>
+    <string>${program}</string>
+    <key>StartInterval</key>
+    <integer>86400</integer>
+</dict>
+</plist>
+PLIST
+}
+
+# Mark a LaunchAgent label as loaded for the mock launchctl.
+#
+# Usage: set_loaded_agents "com.stevegrunwell.asimov" "homebrew.mxcl.asimov"
+set_loaded_agents() {
+    ASIMOV_TEST_LAUNCHCTL_LOADED="$*"
+    export ASIMOV_TEST_LAUNCHCTL_LOADED
+}
+
+# Put a fake `asimov` executable earlier on PATH than the script under test,
+# to simulate a leftover install from an older version shadowing the new one.
+# The stub must never be executed by doctor — it exits 1 loudly if it is.
+#
+# Usage: shadow_asimov_binary <version>   (echoes the directory it created)
+shadow_asimov_binary() {
+    local version="$1"
+    local dir="${TEST_TEMP_DIR}/shadow-bin"
+    mkdir -p "$dir"
+    cat > "${dir}/asimov" <<STUB
+#!/usr/bin/env bash
+# @version ${version}
+echo "STUB WAS EXECUTED" >&2
+exit 1
+STUB
+    chmod +x "${dir}/asimov"
+    export PATH="${dir}:$PATH"
+    echo "$dir"
 }


### PR DESCRIPTION
Closes #122.

[@ajoslin103](https://github.com/ajoslin103) migrated from `0.3.0` to `0.10.0` and hit three bumps. Two of them are our bugs; the third is a documentation gap.

## The crash

`asimov` aborted with nothing but `cat: ~/.cache/asimov/excluded: Permission denied`. Reproduced exactly:

```sh
chmod 000 ~/.cache/asimov/excluded && asimov    # exit 1, one cryptic line
chmod 500 ~/.cache/asimov && asimov             # exit 1, mid-scan
```

The cache is an optimisation, but nothing treated it as optional: a bare `cat` on an unreadable state file fails under `set -Eeu -o pipefail` and takes the run with it.

The cause was Asimov itself. `ensure_cache_dir` chowned the cache *directory* to the console user when running as root, but the state files were created **after** that chown — so every `sudo asimov` left root-owned files behind and broke the next run as the user.

Both halves are fixed. Reads and writes go through `cache_readable`/`cache_writable`, which warn once, name the reset command, and continue without the cache. The state files are created before the chown, and appending never changes an existing file's owner.

One thing this caught: the full-scan branch pipes `find | tee "$ASIMOV_PATH_CACHE" | exclude_paths_from_stdin`, so a failing `tee` takes the pipeline down under `pipefail`. It now falls back to the untee'd pipeline.

## `asimov doctor`

Checks the install rather than the projects, and exits `1` if it finds anything:

```
Install        which asimov the shell actually runs; older ones shadowing it
Schedule       plists present, loaded, and pointing at a program that exists
Cache          readable and writable by you; entry count; last scan
Config         parses, and every section and key is one we understand
Time Machine   tmutil can read exclusions at all (it can't without Full Disk Access)
```

Two rules keep it safe to run part-way through a migration:

- **It never writes.** Fixes are printed, not applied.
- **It never executes another `asimov` binary it finds.** v0.3.0 parses no arguments at all, so running it to ask its version would start a real scan. Versions are read out of the file with `grep`. A test asserts the stub binary is never executed.

## Docs

`UPGRADING.md` gains a v0.3.0 section — the version most people have. Because v0.3.0 ignores `--version` and `--help` too, it opens with a version check that reads the file rather than running it, and puts `asimov doctor` last, after the new binary is in place. It also covers the three leftovers that outlive a v0.3.0 install (the LaunchAgent, the old cellar, the root-owned cache) and notes that Asimov is a one-shot scan, not a daemon — an empty `ps aux | grep asimov` after `brew services start` is expected, not a failure.

## Tests

219 passing, up from 188; shellcheck clean. Written test-first — every behaviour here was red against the pre-fix script before it was green.

- `tests/cache.bats` — 7 tests for unreadable/unwritable state, warn-once, and the `--full-scan` tee path
- `tests/doctor.bats` — 31 tests, including one asserting doctor never executes a binary it finds
- `tests/bin/launchctl` — new mock, driven by `ASIMOV_TEST_LAUNCHCTL_LOADED`
- `tests/test_helper.bash` — now strips any real `asimov` install from `PATH`, since `doctor` inspects `PATH` and would otherwise report a different result on every machine
- `scripts/test.sh` — `doctor.bats` added to the file list

Tests that depend on `chmod` skip when running as root, where they'd be meaningless.
