### PR TITLE
chore(lint): shellcheck the launchctl test mock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ test-system-bash: ## Run Bats tests under the macOS system bash (3.2), as shippe
 	@$(MAKE) --no-print-directory test BASH_BIN=/bin/bash
 
 lint: ## Run Shellcheck on all shell scripts
-	@shellcheck asimov scripts/install.sh scripts/install-remote.sh scripts/uninstall.sh scripts/prep-release.sh scripts/test.sh tests/test_helper.bash tests/bin/run-tests.sh tests/bin/tmutil tests/bin/mdfind
+	@shellcheck asimov scripts/install.sh scripts/install-remote.sh scripts/uninstall.sh scripts/prep-release.sh scripts/test.sh tests/test_helper.bash tests/bin/run-tests.sh tests/bin/tmutil tests/bin/mdfind tests/bin/launchctl
 
 check: test lint ## Run tests and linting
 


### PR DESCRIPTION
The `tests/bin/launchctl` mock added in #123 wasn't added to the `lint` target's file list. Every other script under `tests/bin/` is linted.

It is already clean — this just stops it drifting.