### PR TITLE
docs: release 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Removed
+
+## [0.11.0] — 2026-07-29
+
+### Added
+
 - `asimov doctor` checks an install rather than your projects: which `asimov` your shell
   actually runs (and flags an older one shadowing it on `PATH`), whether a schedule is
   installed and loaded, whether `~/.cache/asimov/` is readable and writable by you,
@@ -349,7 +359,8 @@ v0.8.0, after a `v0.9.0-beta.1`/`beta.2` testing round.
 Initial public release.
 
 
-[Unreleased]: https://github.com/AsimovMac/asimov/compare/v0.10.0...main
+[Unreleased]: https://github.com/AsimovMac/asimov/compare/v0.11.0...main
+[0.11.0]: https://github.com/AsimovMac/asimov/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/AsimovMac/asimov/compare/v0.8.0...v0.10.0
 [0.8.0]: https://github.com/django23/asimov/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/django23/asimov/compare/v0.6.4...v0.7.0

--- a/asimov
+++ b/asimov
@@ -27,7 +27,7 @@ trap 'rm -f "$ASIMOV_SIZE_LOG" "$ASIMOV_EXCLUDED_CACHE" "$ASIMOV_PATH_CACHE_TMP"
 # @license MIT
 
 # Keep ASIMOV_VERSION in sync with CHANGELOG and package managers (e.g. Homebrew).
-readonly ASIMOV_VERSION='0.10.0'
+readonly ASIMOV_VERSION='0.11.0'
 
 print_usage() {
     printf 'Usage: asimov [--dry-run] [--verbose] [--quiet] [--stats] [--no-read-cache] [--no-write-cache] [directory]\n'

--- a/tests/doctor.bats
+++ b/tests/doctor.bats
@@ -34,8 +34,14 @@ require_non_root() {
 }
 
 @test "doctor reports the running version" {
+  # Derived from the script, never hardcoded: a literal here breaks on every
+  # release, which is exactly what it did on the bump to 0.11.0.
+  run_asimov --version
+  local version="$output"
+  [[ -n "$version" ]]
+
   run_asimov doctor
-  [[ "$output" == *"0.10.0"* ]]
+  [[ "$output" == *"$version"* ]]
 }
 
 @test "doctor never modifies Time Machine exclusions" {


### PR DESCRIPTION
Release 0.11.0.

**Added** — `asimov doctor` (#122), and a v0.3.0 section in `UPGRADING.md`.
**Fixed** — an unreadable or unwritable `~/.cache/asimov/` no longer aborts the run, and a run as root no longer leaves root-owned files behind that break the next run (#122).

Also carries a test fix: the `doctor` version assertion hardcoded `0.10.0` and failed on the bump. It now reads the version from `asimov --version`, so it survives every future release.