### PR TITLE
docs: release 0.12.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .idea
 .vscode
 .cursor
+.claude
 CLAUDE.md
 docs/plans/
 docs/triage/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Sentinels, fixed directories and skip paths are now tab-separated data files instead of bash arrays. Each record carries its ecosystem or owning tool as a real field, so adding a pattern is a one-line edit with no bash syntax involved.
 - The remote installer (`scripts/install-remote.sh`) downloads a tarball instead of a single script, and installs under `~/.local`.
 - Release assets are now `asimov-<version>.tar.gz` rather than a bare `asimov` script.
+- The Homebrew formula installs the three pieces under one prefix (`bin/asimov`,
+  `libexec/asimov/`, `share/asimov/`) instead of a single script. `brew install asimov`
+  and `brew services start asimov` are unchanged.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Removed
+
+## [0.12.0] — 2026-07-30
+
+### Added
+
 - Vagrant boxes (`~/.vagrant.d/boxes`) is now one of the built-in global caches, excluded
   when you opt in with `[fixed_dirs] enabled = true`
   ([#117](https://github.com/AsimovMac/asimov/issues/117)).
@@ -372,7 +382,8 @@ v0.8.0, after a `v0.9.0-beta.1`/`beta.2` testing round.
 Initial public release.
 
 
-[Unreleased]: https://github.com/AsimovMac/asimov/compare/v0.11.0...main
+[Unreleased]: https://github.com/AsimovMac/asimov/compare/v0.12.0...main
+[0.12.0]: https://github.com/AsimovMac/asimov/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/AsimovMac/asimov/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/AsimovMac/asimov/compare/v0.8.0...v0.10.0
 [0.8.0]: https://github.com/django23/asimov/compare/v0.7.0...v0.8.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,7 +186,26 @@ make release                                 # signed tag + push (Actions publis
 
 **Homebrew is homebrew-core, and it updates itself.** `asimov` is on Homebrew's autobump list, so BrewTestBot opens the version-bump PR automatically (~3h after a GitHub release) — there is **nothing to do** for a normal version release. Attempting `brew bump-formula-pr` for a version will fail with an autobump-exclusion error.
 
-Only *metadata* changes (homepage, url org, license) need a manual PR against [homebrew-core](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/a/asimov.rb) — edit the formula, `brew style Formula/a/asimov.rb`, then open the PR. The old `django23/homebrew-tap` is archived and no longer used.
+Only *metadata* changes (homepage, url org, license) and changes to the **install stanza**
+need a manual PR against [homebrew-core](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/a/asimov.rb) — edit the formula, `brew style Formula/a/asimov.rb`, then open the PR. The old `django23/homebrew-tap` is archived and no longer used.
+
+**v0.12.0 needs a manual formula PR.** Up to v0.11.0 the repo had a single top-level
+`asimov` script and the formula was `bin.install buildpath/"asimov"`. That file no longer
+exists, so the autobump PR would fail to build. The install stanza has to move to the
+three-piece layout in the same PR as the version bump:
+
+```ruby
+def install
+  bin.install "bin/asimov"
+  libexec.install "lib/asimov"
+  pkgshare.install Dir["data/*"]
+end
+```
+
+`libexec/asimov` and `share/asimov` land next to `bin/asimov` inside the cellar, and the
+launcher resolves the `bin` symlink to its physical path before probing, so it finds both.
+Open this PR yourself as soon as the GitHub release exists rather than waiting for
+BrewTestBot; if the bot gets there first, push the install-stanza fix onto its PR.
 
 If `gh pr create` fails with `Head sha can't be blank` (GraphQL indexing lag), retry once or fall back to the REST API:
 

--- a/bin/asimov
+++ b/bin/asimov
@@ -27,7 +27,7 @@ umask 077
 # Keep ASIMOV_VERSION in sync with CHANGELOG and package managers (e.g. Homebrew).
 # It lives in this file, not in a module, because `asimov doctor` reads the version
 # of other installs by grepping their launcher rather than executing them.
-readonly ASIMOV_VERSION='0.11.0'
+readonly ASIMOV_VERSION='0.12.0'
 
 # Resolve this script to its physical path, following symlinks. Homebrew links
 # bin/asimov into the cellar, so the library sits next to the *target*, not the link.

--- a/scripts/prep-release.sh
+++ b/scripts/prep-release.sh
@@ -96,6 +96,5 @@ Next steps:
   gh pr merge <PR#> --squash --delete-branch
   git checkout main && git pull --ff-only
   make release
-  make ship-formula
   make verify-release
 EOF


### PR DESCRIPTION
Release 0.12.0.

Highlights (see `CHANGELOG.md`):

- **Asimov is no longer a single file** — launcher (`bin/asimov`), library (`lib/asimov/*.sh`), data (`data/*.tsv`).
- `[skip_paths]` config section (#107).
- `~/.vagrant.d/boxes` promoted to a built-in fixed directory (#117).
- `asimov doctor` checks the data files.

Also in this PR:

- `.claude/` gitignored.
- CONTRIBUTING: the Homebrew formula needs a **manual** homebrew-core PR this release. The old stanza was `bin.install buildpath/"asimov"`, and that file is gone, so an autobump PR would fail to build. New stanza documented, verified against a simulated cellar layout.
