### PR TITLE
ci(release): fix the tarball staging path for LICENSE.txt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           # asimov-<version>/{bin,lib,data} and installs with scripts/install.sh.
           STAGE="asimov-${FULL_VERSION}"
           mkdir -p "$STAGE"
-          cp -a bin lib data scripts LICENSE README.md CHANGELOG.md \
+          cp -a bin lib data scripts LICENSE.txt README.md CHANGELOG.md UPGRADING.md \
             com.stevegrunwell.asimov.plist "$STAGE/"
           TARBALL="${STAGE}.tar.gz"
           tar -czf "$TARBALL" "$STAGE"


### PR DESCRIPTION
The v0.12.0 release run failed at `cp: LICENSE: No such file or directory` — the repo file is `LICENSE.txt`. No release or asset was published for the tag.

Also adds `UPGRADING.md` to the tarball.

Verified locally by running the same staging + `tar` commands: the archive unpacks to `asimov-0.12.0/{bin,lib,data,scripts,...}`.

After merge: delete the v0.12.0 tag and release, then re-run `make release`.